### PR TITLE
refactor eCRF exporter - ecrf visits

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/Dao/EcrfDataHorizontal.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Dao/EcrfDataHorizontal.pm
@@ -20,8 +20,6 @@ use CTSMS::BulkProcessor::SqlProcessor qw(
 
 use CTSMS::BulkProcessor::SqlRecord qw();
 
-
-
 require Exporter;
 our @ISA = qw(Exporter CTSMS::BulkProcessor::SqlRecord);
 our @EXPORT_OK = qw(
@@ -33,13 +31,8 @@ our @EXPORT_OK = qw(
     process_records
 );
 
-
-
-
-
 my $tablename = 'ecrf_data_horizontal';
 my $get_db = \&get_csv_db;
-
 
 my $expected_fieldnames;
 _set_expected_fieldnames();
@@ -50,7 +43,6 @@ sub _set_expected_fieldnames {
     my @fieldnames = (
         'proband_id',
 
-
         (sort keys %$listentrytags),
         'subject_group',
         'enrollment_status',
@@ -58,15 +50,6 @@ sub _set_expected_fieldnames {
     push(@fieldnames,@$ecrfvalue_cols);
     $expected_fieldnames = \@fieldnames;
 }
-
-
-
-
-
-
-
-
-
 
 sub new {
 
@@ -172,7 +155,6 @@ sub transformitem {
 
 }
 
-
 sub getinsertstatement {
 
     my ($insert_ignore) = @_;
@@ -180,8 +162,6 @@ sub getinsertstatement {
     return insert_stmt($get_db,__PACKAGE__,$insert_ignore);
 
 }
-
-
 
 sub gettablename {
 

--- a/CTSMS/BulkProcessor/Projects/ETL/Dao/EcrfDataVertical.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Dao/EcrfDataVertical.pm
@@ -50,8 +50,9 @@ sub _set_expected_fieldnames {
         'ecrf_revision',
         'ecrf_external_id',
         'ecrf_id',
-        'ecrf_visit',
+        'ecrf_visits',
         'ecrf_subject_groups',
+        'visit',
         'ecrf_section',
         'ecrf_field_id',
         'ecrf_field_position',
@@ -83,9 +84,9 @@ sub _set_expected_fieldnames {
 }
 
 # table creation:
-my $primarykey_fieldnames = [ 'proband_id','ecrf_name','ecrf_revision','ecrf_section','ecrf_field_position','series_index','value_version' ];
+my $primarykey_fieldnames = [ 'proband_id','ecrf_name','ecrf_revision','visit','ecrf_section','ecrf_field_position','series_index','value_version' ];
 my $indexes = {
-    $tablename . '_ecrf_name_section_position' => [ 'ecrf_name(32)','ecrf_revision(32)','ecrf_section(32)','ecrf_field_position(32)' ],
+    $tablename . '_ecrf_name_section_position' => [ 'ecrf_name(32)','ecrf_revision(32)','visit','ecrf_section(32)','ecrf_field_position(32)' ],
 
 };
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -319,7 +319,6 @@ sub export_ecrf_data_vertical_task {
     my $err = $@;
 
     if ($err) {
-
         push(@$messages,'export_ecrf_data_vertical error: ' . $err);
         return 0;
     } else {

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
@@ -138,6 +138,7 @@ our $proband_list_filename = '%s_%s%s';
 
 my $ecrfname_abbreviate_opts = {};
 my $ecrfrevision_abbreviate_opts = {};
+my $visit_abbreviate_opts = {};
 my $section_abbreviate_opts = {};
 my $inputfieldname_abbreviate_opts = {};
 my $selectionvalue_abbreviate_opts = {};
@@ -165,6 +166,12 @@ our %export_colname_abbreviation = (
         $ecrf_revision = abbreviate(string => $ecrf_revision, %$ecrfrevision_abbreviate_opts);
 
         return $ecrf_revision;
+    },
+    abbreviate_visit_code => sub {
+        my ($visit_token,$visit_title,$visit_id) = @_;
+        $visit_token = abbreviate(string => $visit_token, %$visit_abbreviate_opts);
+
+        return $visit_token;
     },
     abbreviate_section_code => sub {
         my $section = shift;
@@ -318,6 +325,7 @@ sub update_settings {
         $export_colname_abbreviation{ignore_external_ids} = $data->{ignore_external_ids} if exists $data->{ignore_external_ids};
         $ecrfname_abbreviate_opts = $data->{ecrfname_abbreviate_opts} if exists $data->{ecrfname_abbreviate_opts};
         $ecrfrevision_abbreviate_opts = $data->{ecrfrevision_abbreviate_opts} if exists $data->{ecrfrevision_abbreviate_opts};
+        $visit_abbreviate_opts = $data->{visit_abbreviate_opts} if exists $data->{visit_abbreviate_opts};
         $inputfieldname_abbreviate_opts = $data->{inputfieldname_abbreviate_opts} if exists $data->{inputfieldname_abbreviate_opts};
         $selectionvalue_abbreviate_opts = $data->{selectionvalue_abbreviate_opts} if exists $data->{selectionvalue_abbreviate_opts};
 

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/proband/ProbandService/InquiryValues.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/proband/ProbandService/InquiryValues.pm
@@ -157,21 +157,11 @@ sub transformitem {
     $item->{js_rows} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryJsonValue::builditems_fromrows($item->{js_rows},$load_recursive,$restapi);
 }
 
-sub get_item_path {
-
-    my ($id) = @_;
-    return &$get_item_path_query($id);
-
-}
-
-
-
-
-
-
-
-
-
-
+#sub get_item_path {
+#
+#    my ($id) = @_;
+#    return &$get_item_path_query($id);
+#
+#}
 
 1;

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/Ecrf.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/Ecrf.pm
@@ -42,9 +42,10 @@ my $get_trial_path_query = sub {
     return 'trial/' . $trial_id . '/list/ecrf' . get_query_string(\%params);
 };
 my $get_getecrffieldvaluessectionmaxindex_path_query = sub {
-    my ($ecrf_id, $section) = @_;
+    my ($ecrf_id, $visit_id, $section) = @_;
     my %params = ();
     $params{section} = $section;
+    $params{visit_id} = $visit_id if defined $visit_id;
     return 'ecrf/' . $ecrf_id . '/ecrffieldvalues/maxindex' . get_query_string(\%params);
 };
 
@@ -66,7 +67,7 @@ my $fieldnames = [
     "trial",
     "uniqueName",
     "version",
-    "visit",
+    "visits",
     "deferredDelete",
     "deferredDeleteReason",
 ];
@@ -100,9 +101,9 @@ sub get_trial_list {
 
 sub get_getecrffieldvaluessectionmaxindex {
 
-    my ($ecrf_id, $section, $restapi,$headers) = @_;
+    my ($ecrf_id, $visit_id, $section, $restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return $api->get(&$get_getecrffieldvaluessectionmaxindex_path_query($ecrf_id, $section),$headers);
+    return $api->get(&$get_getecrffieldvaluessectionmaxindex_path_query($ecrf_id, $visit_id, $section),$headers);
 
 }
 

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfField.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfField.pm
@@ -144,11 +144,13 @@ sub get_item_path {
 sub get_export_colnames {
     my %params = @_;
     my ($ecrffield,
+        $visit,
         $index,
         $get_colname_parts_code,
         $ignore_external_ids,
         $abbreviate_ecrf_name_code,
         $abbreviate_ecrf_revision_code,
+        $abbreviate_visit_code,
         $abbreviate_section_code,
         $abbreviate_inputfield_name_code,
         $abbreviate_selectionvalue_code,
@@ -158,11 +160,13 @@ sub get_export_colnames {
         $selectionValues,
         $sanitize_colname_symbols_code) = @params{qw/
             ecrffield
+            visit
             index
             get_colname_parts_code
             ignore_external_ids
             abbreviate_ecrf_name_code
             abbreviate_ecrf_revision_code
+            abbreviate_visit_code
             abbreviate_section_code
             abbreviate_inputfield_name_code
             abbreviate_selectionvalue_code
@@ -179,7 +183,7 @@ sub get_export_colnames {
     $selectionSetValues //= [];
     my @export_colnames = ();
     my $prefix;
-    my @parts = &$get_colname_parts_code($ecrffield,$index);
+    my @parts = &$get_colname_parts_code($ecrffield,$visit,$index);
     unless ((scalar @parts) > 0) {
         my $external_id_used = 0;
         if (not $ignore_external_ids and defined $ecrffield->{ecrf}->{externalId} and length($ecrffield->{ecrf}->{externalId}) > 0) {
@@ -192,6 +196,11 @@ sub get_export_colnames {
             push(@parts,$ecrf_name) if defined $ecrf_name and length($ecrf_name) > 0;
             my $ecrf_revision = &$abbreviate_ecrf_revision_code($ecrffield->{ecrf}->{revision});
             push(@parts,$ecrf_revision) if defined $ecrf_revision and length($ecrf_revision) > 0;
+        }
+        if (defined $visit) {
+            $abbreviate_visit_code = sub { return shift; } unless 'CODE' eq ref $abbreviate_visit_code;
+            my $visit_token = &$abbreviate_visit_code($visit->{token},$visit->{title},$visit->{id});
+            push(@parts,$visit_token) if defined $visit_token and length($visit_token) > 0;
         }
         $index_digits //= 2;
         if (not $ignore_external_ids and defined $ecrffield->{externalId} and length($ecrffield->{externalId}) > 0) {

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldJsonValue.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldJsonValue.pm
@@ -46,7 +46,8 @@ my $fieldnames = [
     "timestampValue",
     "userTimeZone",
     "probandGroupTokens",
-    "visitToken",
+    "visitTokens",
+    "visitId",
 ];
 
 sub new {

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldValue.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldValue.pm
@@ -37,8 +37,10 @@ my $get_item_path_query = sub {
     return 'ecrffieldvalue/' . $id;
 };
 my $get_clear_path_query = sub {
-    my ($listentry_id, $ecrf_id) = @_;
-    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . '/ecrffieldvalues';
+    my ($listentry_id, $ecrf_id, $visit_id) = @_;
+    my %params = ();
+    $params{visit_id} = $visit_id if defined $visit_id;
+    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . '/ecrffieldvalues' . get_query_string(\%params);
 };
 
 my $fieldnames = [
@@ -62,7 +64,7 @@ my $fieldnames = [
     "timeValue",
     "timestampValue",
     "version",
-
+    "visit",
 ];
 
 sub new {
@@ -86,9 +88,9 @@ sub get_item {
 
 sub clear {
 
-    my ($listentry_id, $ecrf_id, $restapi,$headers) = @_;
+    my ($listentry_id, $ecrf_id, $visit_id, $restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return builditems_fromrows($api->delete(&$get_clear_path_query($listentry_id, $ecrf_id),$headers));
+    return builditems_fromrows($api->delete(&$get_clear_path_query($listentry_id, $ecrf_id, $visit_id),$headers));
 
 }
 
@@ -122,6 +124,7 @@ sub builditems_fromrows {
 sub transformitem {
     my ($item,$load_recursive,$restapi) = @_;
     $item->{ecrfField} = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfField::builditems_fromrows($item->{ecrfField},$load_recursive,$restapi);
+    #$item->{visit} = ...
     $item->{inkValues} = utf8bytes_to_string($item->{inkValues});
     $item->{selectionValues} = CTSMS::BulkProcessor::RestRequests::ctsms::shared::InputFieldService::InputFieldSelectionSetValue::builditems_fromrows($item->{selectionValues},$load_recursive,$restapi);
     if ($load_recursive) {

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldValues.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfFieldValues.pm
@@ -30,19 +30,24 @@ our @EXPORT_OK = qw(
 
     get_ecrffieldvalues
     set_ecrffieldvalues
-    get_getecrffieldvaluessectionmaxindex
+
 
 );
+#get_getecrffieldvaluessectionmaxindex
 
 my $default_restapi = \&get_ctsms_restapi;
 my $get_item_path_query = sub {
-    my ($listentry_id, $ecrffield_id, $index) = @_;
-    return 'ecrfstatusentry/' . $listentry_id . '/ecrffieldvalue/' . $ecrffield_id . (defined $index ? '/' . $index : '');
+    my ($listentry_id, $visit_id, $ecrffield_id, $index) = @_;
+    my %params = ();
+    $params{visit_id} = $visit_id if defined $visit_id;
+    $params{index} = $index if defined $index;
+    return 'ecrfstatusentry/' . $listentry_id . '/ecrffieldvalue/' . $ecrffield_id . get_query_string(\%params);
 };
 my $get_getecrffieldvalues_path_query = sub {
-    my ($listentry_id, $ecrf_id, $load_all_js_values) = @_;
+    my ($listentry_id, $ecrf_id, $visit_id, $load_all_js_values) = @_;
     my %params = ();
     $params{load_all_js_values} = booltostring($load_all_js_values);
+    $params{visit_id} = $visit_id if defined $visit_id;
     return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . '/ecrffieldvalues' . get_query_string(\%params);
 };
 
@@ -52,12 +57,13 @@ my $get_setecrffieldvalues_path_query = sub {
     $params{force} = booltostring($force) if defined $force;
     return 'ecrffieldvalue/' . get_query_string(\%params);
 };
-my $get_getecrffieldvaluessectionmaxindex_path_query = sub {
-    my ($listentry_id, $ecrf_id, $section) = @_;
-    my %params = ();
-    $params{section} = $section;
-    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . '/ecrffieldvalues/maxindex' . get_query_string(\%params);
-};
+#my $get_getecrffieldvaluessectionmaxindex_path_query = sub {
+#    my ($listentry_id, $ecrf_id, $visit_id, $section) = @_;
+#    my %params = ();
+#    $params{section} = $section;
+#    $params{visit_id} = $visit_id if defined $visit_id;
+#    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . '/ecrffieldvalues/maxindex' . get_query_string(\%params);
+#};
 
 my $fieldnames = [
     "rows",
@@ -77,17 +83,17 @@ sub new {
 
 sub get_item {
 
-    my ($listentry_id, $ecrffield_id, $index,$load_recursive,$restapi,$headers) = @_;
+    my ($listentry_id, $visit_id, $ecrffield_id, $index,$load_recursive,$restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return builditems_fromrows($api->get(&$get_item_path_query($listentry_id, $ecrffield_id, $index),$headers),$load_recursive,$restapi);
+    return builditems_fromrows($api->get(&$get_item_path_query($listentry_id, $visit_id, $ecrffield_id, $index),$headers),$load_recursive,$restapi);
 
 }
 
 sub get_ecrffieldvalues {
 
-    my ($listentry_id, $ecrf_id, $load_all_js_values, $p,$sf,$load_recursive,$restapi,$headers) = @_;
+    my ($listentry_id, $ecrf_id, $visit_id, $load_all_js_values, $p,$sf,$load_recursive,$restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return builditems_fromrows($api->extract_collection_items($api->get($api->get_collection_page_query_uri(&$get_getecrffieldvalues_path_query($listentry_id, $ecrf_id, $load_all_js_values),$p,$sf),$headers),$p),$load_recursive,$restapi);
+    return builditems_fromrows($api->extract_collection_items($api->get($api->get_collection_page_query_uri(&$get_getecrffieldvalues_path_query($listentry_id, $ecrf_id, $visit_id, $load_all_js_values),$p,$sf),$headers),$p),$load_recursive,$restapi);
 
 }
 
@@ -99,13 +105,13 @@ sub set_ecrffieldvalues {
 
 }
 
-sub get_getecrffieldvaluessectionmaxindex {
-
-    my ($listentry_id, $ecrf_id, $section, $restapi,$headers) = @_;
-    my $api = _get_api($restapi,$default_restapi);
-    return $api->get(&$get_getecrffieldvaluessectionmaxindex_path_query($listentry_id, $ecrf_id, $section),$headers);
-
-}
+#sub get_getecrffieldvaluessectionmaxindex {
+#
+#    my ($listentry_id, $ecrf_id, $visit_id, $section, $restapi,$headers) = @_;
+#    my $api = _get_api($restapi,$default_restapi);
+#    return $api->get(&$get_getecrffieldvaluessectionmaxindex_path_query($listentry_id, $ecrf_id, $visit_id, $section),$headers);
+#
+#}
 
 sub builditems_fromrows {
 
@@ -141,11 +147,11 @@ sub transformitem {
 
 }
 
-sub get_item_path {
-
-    my ($id) = @_;
-    return &$get_item_path_query($id);
-
-}
+#sub get_item_path {
+#
+#    my ($id) = @_;
+#    return &$get_item_path_query($id);
+#
+#}
 
 1;

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfStatusEntry.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/EcrfStatusEntry.pm
@@ -30,13 +30,16 @@ our @EXPORT_OK = qw(
 
 my $default_restapi = \&get_ctsms_restapi;
 my $get_item_path_query = sub {
-    my ($listentry_id,$ecrf_id) = @_;
-    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id;
+    my ($listentry_id,$ecrf_id,$visit_id) = @_;
+    my %params = ();
+    $params{visit_id} = $visit_id if defined $visit_id;
+    return 'ecrfstatusentry/' . $listentry_id . '/' . $ecrf_id . get_query_string(\%params);
 };
 my $get_renderecrf_path_query = sub {
-    my ($listentry_id,$ecrf_id,$blank) = @_;
+    my ($listentry_id,$ecrf_id,$visit_id,$blank) = @_;
     my %params = ();
     $params{blank} = booltostring($blank);
+    $params{visit_id} = $visit_id if defined $visit_id;
     return 'ecrfstatusentry/' . $listentry_id . '/ecrfpdf' . ((defined $ecrf_id) ? '/' . $ecrf_id : '') . get_query_string(\%params);;
 };
 
@@ -54,6 +57,7 @@ my $fieldnames = [
     "validationStatus",
     "validationTimestamp",
     "version",
+    "visit",
 ];
 
 sub new {
@@ -69,17 +73,17 @@ sub new {
 
 sub get_item {
 
-    my ($listentry_id,$ecrf_id,$load_recursive,$restapi,$headers) = @_;
+    my ($listentry_id,$ecrf_id,$visit_id,$load_recursive,$restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return builditems_fromrows($api->get(&$get_item_path_query($listentry_id,$ecrf_id),$headers),$load_recursive,$restapi);
+    return builditems_fromrows($api->get(&$get_item_path_query($listentry_id,$ecrf_id,$visit_id),$headers),$load_recursive,$restapi);
 
 }
 
 sub render_ecrf {
 
-    my ($listentry_id,$ecrf_id,$blank,$restapi,$headers) = @_;
+    my ($listentry_id,$ecrf_id,$visit_id,$blank,$restapi,$headers) = @_;
     my $api = _get_api($restapi,$default_restapi);
-    return $api->get_file(&$get_renderecrf_path_query($listentry_id,$ecrf_id,$blank),$headers);
+    return $api->get_file(&$get_renderecrf_path_query($listentry_id,$ecrf_id,$visit_id,$blank),$headers);
 
 }
 
@@ -115,12 +119,11 @@ sub transformitem {
 
 }
 
-sub get_item_path {
-
-    my ($id) = @_;
-    return &$get_item_path_query($id);
-
-}
-
+#sub get_item_path {
+#
+#    my ($id) = @_;
+#    return &$get_item_path_query($id);
+#
+#}
 
 1;

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/ProbandListEntryTagValues.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/trial/TrialService/ProbandListEntryTagValues.pm
@@ -162,21 +162,11 @@ sub transformitem {
 
 }
 
-sub get_item_path {
-
-    my ($id) = @_;
-    return &$get_item_path_query($id);
-
-}
-
-
-
-
-
-
-
-
-
-
+#sub get_item_path {
+#
+#   my ($id) = @_;
+#    return &$get_item_path_query($id);
+#
+#}
 
 1;


### PR DESCRIPTION
extend exporting the eCRF data by deflating the all-new "visit" dimension:

- paging iterations (subjects->ecrfs->data values) for limited memeory footprint while exporting large datasets is extended to iterated visits (subjects->ecrfs->visits->data values)
- include visit in column name abbreviation algorithm, see https://github.com/phoenixctms/config-default/pull/5
- vertical data also includes ecrf groups and visits lists
- add visit parameter to request response ValueObjects and/or query parameters