### PR TITLE
support Bearer JWT auth for CtsmsRestApi and ETL --auth jobs

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
@@ -59,6 +59,8 @@ our @EXPORT_OK = qw(
     
     $publish_public_file
 
+    $JWT_VALIDITY_SECS
+
 );
 
 our $defaultconfig = 'config.cfg';
@@ -87,6 +89,8 @@ our $proband_list_filename = '%s_%s%s';
 our $publish_public_file = 0;
 
 our $ecrf_data_row_block = 100;
+
+our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -117,7 +121,9 @@ sub update_settings {
 
         $ecrf_data_row_block = $data->{ecrf_data_row_block} if exists $data->{ecrf_data_row_block};
         
-        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};        
+        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};
+
+        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};        
 
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -17,7 +17,7 @@ use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_rest_api_jwt
+    issue_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $output_path
@@ -190,7 +190,7 @@ sub init {
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -13,6 +13,12 @@ use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
 );
+use CTSMS::BulkProcessor::ConnectorPool qw(
+    get_ctsms_restapi
+);
+use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
+    issue_rest_api_jwt
+);
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $output_path
     $skip_errors
@@ -32,6 +38,7 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings qw(
     $defaultsettings
     $defaultconfig
     $force
+    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -178,6 +185,8 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        my $api = get_ctsms_restapi();
+        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -185,11 +185,13 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
-        my $api = get_ctsms_restapi();
-        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {
+        if ($auth) {
+            my $api = get_ctsms_restapi();
+            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+        }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::Job::update_settings,$YAML_CONFIG_TYPE,undef,

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/Settings.pm
@@ -55,6 +55,8 @@ our @EXPORT_OK = qw(
     
     $ecrf_name_column_name
     $ecrf_visit_column_name
+
+    $JWT_VALIDITY_SECS
     
     get_ecrf_columns
 
@@ -81,6 +83,8 @@ our $append_selection_set_values;
 
 our $ecrf_name_column_name = 'ecrf';
 our $ecrf_visit_column_name = 'visit';
+
+our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -109,6 +113,8 @@ sub update_settings {
         
         $ecrf_name_column_name = $data->{ecrf_name_column_name} if exists $data->{ecrf_name_column_name};
         $ecrf_visit_column_name = $data->{ecrf_visit_column_name} if exists $data->{ecrf_visit_column_name};
+
+        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};
 
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -13,6 +13,12 @@ use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
 );
+use CTSMS::BulkProcessor::ConnectorPool qw(
+    get_ctsms_restapi
+);
+use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
+    issue_rest_api_jwt
+);
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $skip_errors
     $timezone
@@ -33,6 +39,7 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings qw(
     $force
     $clear_sections
     $clear_all_sections
+    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -120,6 +127,8 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        my $api = get_ctsms_restapi();
+        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -17,7 +17,7 @@ use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_rest_api_jwt
+    issue_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $skip_errors
@@ -132,7 +132,7 @@ sub init {
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -127,11 +127,13 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
-        my $api = get_ctsms_restapi();
-        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {
+        if ($auth) {
+            my $api = get_ctsms_restapi();
+            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+        }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::Job::update_settings,$YAML_CONFIG_TYPE,undef,

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/Settings.pm
@@ -55,6 +55,8 @@ our @EXPORT_OK = qw(
     
     $publish_public_file
 
+    $JWT_VALIDITY_SECS
+
 );
 
 our $defaultconfig = 'config.cfg';
@@ -76,6 +78,8 @@ our $inquiry_data_export_pdfs_filename = '%s_%s%s';
 our $publish_public_file = 0;
 
 our $inquiry_data_row_block = 100;
+
+our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -99,7 +103,9 @@ sub update_settings {
         
         $inquiry_data_row_block = $data->{inquiry_data_row_block} if exists $data->{inquiry_data_row_block};
         
-        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};        
+        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};
+
+        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};        
         
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -17,7 +17,7 @@ use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_rest_api_jwt
+    issue_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $output_path
@@ -155,7 +155,7 @@ sub init {
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -150,11 +150,13 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
-        my $api = get_ctsms_restapi();
-        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {
+        if ($auth) {
+            my $api = get_ctsms_restapi();
+            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+        }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::Job::update_settings,$YAML_CONFIG_TYPE,undef,

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -13,6 +13,12 @@ use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
 );
+use CTSMS::BulkProcessor::ConnectorPool qw(
+    get_ctsms_restapi
+);
+use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
+    issue_rest_api_jwt
+);
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $output_path
     $skip_errors
@@ -31,6 +37,7 @@ use CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings qw(
     $defaultsettings
     $defaultconfig
     $force
+    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -143,6 +150,8 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        my $api = get_ctsms_restapi();
+        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/Settings.pm
@@ -51,6 +51,8 @@ our @EXPORT_OK = qw(
     $clear_all_categories
 
     $inquiry_values_col_block
+
+    $JWT_VALIDITY_SECS
     
 );
 
@@ -70,6 +72,8 @@ our $inquiry_values_col_block = 1; # save one inquiry value after the other
 our $clear_categories;
 our $clear_all_categories;
 our $append_selection_set_values;
+
+our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -94,6 +98,8 @@ sub update_settings {
         $update_listentrytag_values = $data->{update_listentrytag_values} if exists $data->{update_listentrytag_values};
 
         $inquiry_values_col_block = $data->{inquiry_values_col_block} if exists $data->{inquiry_values_col_block};
+
+        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};
         
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -13,6 +13,12 @@ use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
 );
+use CTSMS::BulkProcessor::ConnectorPool qw(
+    get_ctsms_restapi
+);
+use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
+    issue_rest_api_jwt
+);
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $skip_errors
     $timezone
@@ -33,6 +39,7 @@ use CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings qw(
     $force
     $clear_categories
     $clear_all_categories
+    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -120,6 +127,8 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        my $api = get_ctsms_restapi();
+        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -127,11 +127,13 @@ sub init {
     #support credentials via args for jobs:
     if ($auth) {
         ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
-        my $api = get_ctsms_restapi();
-        $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
     }
     init_log();
     eval {
+        if ($auth) {
+            my $api = get_ctsms_restapi();
+            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+        }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::Job::update_settings,$YAML_CONFIG_TYPE,undef,

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -17,7 +17,7 @@ use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_rest_api_jwt
+    issue_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $skip_errors
@@ -132,7 +132,7 @@ sub init {
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_rest_api_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/WebApps/Signup/Utils.pm
+++ b/CTSMS/BulkProcessor/Projects/WebApps/Signup/Utils.pm
@@ -62,7 +62,7 @@ our @EXPORT_OK = qw(
     get_ctsms_baseuri
     get_restapi_uri
     get_rest_api_jwt
-    issue_rest_api_jwt
+    issue_jwt
     $restapi
     get_site
     get_site_name
@@ -644,13 +644,13 @@ sub get_rest_api_jwt {
     if (defined $cached && 'HASH' eq ref $cached && ($cached->{key} // '') eq $key && defined $cached->{jwt} && length($cached->{jwt}) > 0) {
         return $cached->{jwt};
     }
-    return issue_rest_api_jwt();
+    return issue_jwt();
 }
 
-sub issue_rest_api_jwt {
+sub issue_jwt {
     my $key = _get_rest_api_jwt_session_key();
     eval {
-        my $jwt = CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login::issue_rest_api_jwt(
+        my $jwt = CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login::issue_jwt(
             Dancer::config->{session_expires},
             get_restapi(),
         );

--- a/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
+++ b/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
@@ -94,11 +94,28 @@ sub setup {
 
 }
 
+sub jwt {
+
+    my $self = shift;
+    if (@_) {
+        my $jwt = shift;
+        undef $self->{ua};
+        $self->{jwt} = (defined $jwt && length($jwt) > 0) ? $jwt : undef;
+    }
+    return $self->{jwt};
+
+}
+
 sub connectidentifier {
 
     my $self = shift;
     if ($self->{uri}) {
-        return ($self->{username} ? $self->{username} . '@' : '') . $self->{uri};
+        if ($self->{username}) {
+            return $self->{username} . '@' . $self->{uri};
+        } elsif ($self->{jwt}) {
+            return 'jwt@' . $self->{uri};
+        }
+        return $self->{uri};
     } else {
         return undef;
     }
@@ -114,7 +131,9 @@ sub _setup_ua {
 		SSL_verify_mode => 0,
 	);
     $ua->timeout($timeout) if $timeout;
-    if ($self->{username}) {
+    if ($self->{jwt}) {
+        $ua->default_header('Authorization' => 'Bearer ' . $self->{jwt});
+    } elsif ($self->{username}) {
         $ua->credentials($netloc, $self->{realm}, $self->{username}, $self->{password});
     }
     restdebug($self,"ua configured",getlogger(__PACKAGE__));

--- a/CTSMS/BulkProcessor/RestRequests/ctsms/shared/ToolsService/Login.pm
+++ b/CTSMS/BulkProcessor/RestRequests/ctsms/shared/ToolsService/Login.pm
@@ -16,7 +16,7 @@ use CTSMS::BulkProcessor::RestConnectors::CtsmsRestApi qw(_get_api);
 require Exporter;
 our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
-    issue_rest_api_jwt
+    issue_jwt
 );
 
 my $default_restapi = \&get_ctsms_restapi;
@@ -27,7 +27,7 @@ my $get_login_path_query = sub {
     return 'tools/login' . get_query_string(\%params);
 };
 
-sub issue_rest_api_jwt {
+sub issue_jwt {
 
     my ($validity_secs, $restapi, $headers) = @_;
     my $api = _get_api($restapi, $default_restapi);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added JWT-based authentication for ECRF and inquiry import/export processes.
  - ETL jobs now automatically establish secure REST API sessions when credentials are provided.
  - JWT validity can be configured, with a default duration of one year.
  - REST API requests support bearer-token authentication while retaining username/password authentication as a fallback.
- **Configuration**
  - Added an optional `jwt_validity_secs` setting to control token lifetime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->