### PR TITLE
pass JWT for job auth

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
@@ -59,8 +59,6 @@ our @EXPORT_OK = qw(
     
     $publish_public_file
 
-    $JWT_VALIDITY_SECS
-
 );
 
 our $defaultconfig = 'config.cfg';
@@ -89,8 +87,6 @@ our $proband_list_filename = '%s_%s%s';
 our $publish_public_file = 0;
 
 our $ecrf_data_row_block = 100;
-
-our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -121,9 +117,7 @@ sub update_settings {
 
         $ecrf_data_row_block = $data->{ecrf_data_row_block} if exists $data->{ecrf_data_row_block};
         
-        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};
-
-        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};        
+        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};        
 
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -7,7 +7,6 @@ use Cwd;
 use lib Cwd::abs_path(File::Basename::dirname(__FILE__) . '/../../../../../');
 
 use Getopt::Long qw(GetOptions);
-use MIME::Base64 qw(decode_base64);
 
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
@@ -16,8 +15,8 @@ use CTSMS::BulkProcessor::Globals qw(
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
-use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_jwt
+use CTSMS::BulkProcessor::RestConnector qw(
+    get_username_from_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $output_path
@@ -38,7 +37,6 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings qw(
     $defaultsettings
     $defaultconfig
     $force
-    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -182,15 +180,15 @@ sub init {
     );
 
     my $result = load_config($configfile);
-    #support credentials via args for jobs:
+    #support jwt via args for jobs:
     if ($auth) {
-        ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        $ctsmsrestapi_username = get_username_from_jwt($auth);
     }
     init_log();
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt($auth);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -181,12 +181,10 @@ sub init {
 
     my $result = load_config($configfile);
     #support jwt via args for jobs:
-    if ($auth) {
-        $ctsmsrestapi_username = get_username_from_jwt($auth);
-    }
     init_log();
     eval {
         if ($auth) {
+            $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
         }

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/Settings.pm
@@ -55,8 +55,6 @@ our @EXPORT_OK = qw(
     
     $ecrf_name_column_name
     $ecrf_visit_column_name
-
-    $JWT_VALIDITY_SECS
     
     get_ecrf_columns
 
@@ -83,8 +81,6 @@ our $append_selection_set_values;
 
 our $ecrf_name_column_name = 'ecrf';
 our $ecrf_visit_column_name = 'visit';
-
-our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -113,8 +109,6 @@ sub update_settings {
         
         $ecrf_name_column_name = $data->{ecrf_name_column_name} if exists $data->{ecrf_name_column_name};
         $ecrf_visit_column_name = $data->{ecrf_visit_column_name} if exists $data->{ecrf_visit_column_name};
-
-        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};
 
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -7,7 +7,6 @@ use Cwd;
 use lib Cwd::abs_path(File::Basename::dirname(__FILE__) . '/../../../../../');
 
 use Getopt::Long qw(GetOptions);
-use MIME::Base64 qw(decode_base64);
 
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
@@ -16,8 +15,8 @@ use CTSMS::BulkProcessor::Globals qw(
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
-use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_jwt
+use CTSMS::BulkProcessor::RestConnector qw(
+    get_username_from_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $skip_errors
@@ -39,7 +38,6 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings qw(
     $force
     $clear_sections
     $clear_all_sections
-    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -124,15 +122,15 @@ sub init {
     );
 
     my $result = load_config($configfile);
-    #support credentials via args for jobs:
+    #support jwt via args for jobs:
     if ($auth) {
-        ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        $ctsmsrestapi_username = get_username_from_jwt($auth);
     }
     init_log();
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt($auth);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -123,12 +123,10 @@ sub init {
 
     my $result = load_config($configfile);
     #support jwt via args for jobs:
-    if ($auth) {
-        $ctsmsrestapi_username = get_username_from_jwt($auth);
-    }
     init_log();
     eval {
         if ($auth) {
+            $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
         }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/Settings.pm
@@ -55,8 +55,6 @@ our @EXPORT_OK = qw(
     
     $publish_public_file
 
-    $JWT_VALIDITY_SECS
-
 );
 
 our $defaultconfig = 'config.cfg';
@@ -78,8 +76,6 @@ our $inquiry_data_export_pdfs_filename = '%s_%s%s';
 our $publish_public_file = 0;
 
 our $inquiry_data_row_block = 100;
-
-our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -103,9 +99,7 @@ sub update_settings {
         
         $inquiry_data_row_block = $data->{inquiry_data_row_block} if exists $data->{inquiry_data_row_block};
         
-        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};
-
-        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};        
+        $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};        
         
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -146,12 +146,10 @@ sub init {
 
     my $result = load_config($configfile);
     #support jwt via args for jobs:
-    if ($auth) {
-        $ctsmsrestapi_username = get_username_from_jwt($auth);
-    }
     init_log();
     eval {
         if ($auth) {
+            $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
         }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -7,7 +7,6 @@ use Cwd;
 use lib Cwd::abs_path(File::Basename::dirname(__FILE__) . '/../../../../../');
 
 use Getopt::Long qw(GetOptions);
-use MIME::Base64 qw(decode_base64);
 
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
@@ -16,8 +15,8 @@ use CTSMS::BulkProcessor::Globals qw(
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
-use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_jwt
+use CTSMS::BulkProcessor::RestConnector qw(
+    get_username_from_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $output_path
@@ -37,7 +36,6 @@ use CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings qw(
     $defaultsettings
     $defaultconfig
     $force
-    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -147,15 +145,15 @@ sub init {
     );
 
     my $result = load_config($configfile);
-    #support credentials via args for jobs:
+    #support jwt via args for jobs:
     if ($auth) {
-        ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        $ctsmsrestapi_username = get_username_from_jwt($auth);
     }
     init_log();
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt($auth);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/Settings.pm
@@ -51,8 +51,6 @@ our @EXPORT_OK = qw(
     $clear_all_categories
 
     $inquiry_values_col_block
-
-    $JWT_VALIDITY_SECS
     
 );
 
@@ -72,8 +70,6 @@ our $inquiry_values_col_block = 1; # save one inquiry value after the other
 our $clear_categories;
 our $clear_all_categories;
 our $append_selection_set_values;
-
-our $JWT_VALIDITY_SECS = 365 * 24 * 60 * 60;
 
 sub update_settings {
 
@@ -98,8 +94,6 @@ sub update_settings {
         $update_listentrytag_values = $data->{update_listentrytag_values} if exists $data->{update_listentrytag_values};
 
         $inquiry_values_col_block = $data->{inquiry_values_col_block} if exists $data->{inquiry_values_col_block};
-
-        $JWT_VALIDITY_SECS = $data->{jwt_validity_secs} if exists $data->{jwt_validity_secs};
         
         return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -7,7 +7,6 @@ use Cwd;
 use lib Cwd::abs_path(File::Basename::dirname(__FILE__) . '/../../../../../');
 
 use Getopt::Long qw(GetOptions);
-use MIME::Base64 qw(decode_base64);
 
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
@@ -16,8 +15,8 @@ use CTSMS::BulkProcessor::Globals qw(
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
 );
-use CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login qw(
-    issue_jwt
+use CTSMS::BulkProcessor::RestConnector qw(
+    get_username_from_jwt
 );
 use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $skip_errors
@@ -39,7 +38,6 @@ use CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings qw(
     $force
     $clear_categories
     $clear_all_categories
-    $JWT_VALIDITY_SECS
 );
 use CTSMS::BulkProcessor::Logging qw(
     init_log
@@ -124,15 +122,15 @@ sub init {
     );
 
     my $result = load_config($configfile);
-    #support credentials via args for jobs:
+    #support jwt via args for jobs:
     if ($auth) {
-        ($ctsmsrestapi_username,$ctsmsrestapi_password) = split("\n",decode_base64($auth),2);
+        $ctsmsrestapi_username = get_username_from_jwt($auth);
     }
     init_log();
     eval {
         if ($auth) {
             my $api = get_ctsms_restapi();
-            $api->jwt(issue_jwt($JWT_VALIDITY_SECS, $api));
+            $api->jwt($auth);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -123,12 +123,10 @@ sub init {
 
     my $result = load_config($configfile);
     #support jwt via args for jobs:
-    if ($auth) {
-        $ctsmsrestapi_username = get_username_from_jwt($auth);
-    }
     init_log();
     eval {
         if ($auth) {
+            $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
         }

--- a/CTSMS/BulkProcessor/RestConnector.pm
+++ b/CTSMS/BulkProcessor/RestConnector.pm
@@ -5,6 +5,10 @@ use strict;
 
 use Scalar::Util 'blessed';
 
+use MIME::Base64 qw(decode_base64);
+
+use JSON -support_by_pp, -no_export;
+
 use URI;
 use LWP::UserAgent qw();
 
@@ -26,6 +30,7 @@ our @ISA = qw(Exporter);
 our @EXPORT_OK = qw(
     _add_headers
     convert_bools
+    get_username_from_jwt
 );
 
 sub new {
@@ -671,6 +676,29 @@ sub convert_bools {
 
     carp("Encountered an object of unrecognized type $_")
         for sort values(%unrecognized);
+}
+
+sub _decode_jwt_payload {
+    my ($jwt) = @_;
+    return undef unless defined $jwt && length($jwt) > 0;
+    my @parts = split(/\./, $jwt, 3);
+    return undef if scalar @parts < 2 || length($parts[1]) == 0;
+    my $payload = $parts[1];
+    $payload =~ tr/-_/+\//;
+    my $padding = (4 - length($payload) % 4) % 4;
+    $payload .= '=' x $padding;
+    my $decoded;
+    eval {
+        $decoded = JSON::from_json(decode_base64($payload), { allow_nonref => 1 });
+    };
+    return $@ ? undef : $decoded;
+}
+
+sub get_username_from_jwt {
+    my ($jwt) = @_;
+    my $payload = _decode_jwt_payload($jwt);
+    return undef unless defined $payload && 'HASH' eq ref $payload;
+    return $payload->{sub} // $payload->{username};
 }
 
 sub get_last_error {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ETL import and export jobs now accept pre-issued JWT tokens directly for authentication.
  * Added support for identifying the authenticated username from a JWT.
* **Configuration**
  * Removed the configurable JWT validity period from ETL job settings.
  * Existing public-file publishing configuration remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->