### PR TITLE
signup: fix select-one apply setValue and reject multi-id calculated values

### DIFF
--- a/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/fieldcalculation/fieldCalculation.js
+++ b/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/fieldcalculation/fieldCalculation.js
@@ -198,6 +198,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " darf nicht angekreuzt sein",
 	    'mustBeUnselected'       : " darf nicht gesetzt sein",
 	    'mustBeUnmarked'         : " darf nicht markiert sein",
+	    'selectOneMultipleSelectionIds' : "darf höchstens eine Auswahl-ID liefern (erhalten: %d)",
 
 	    'true'                   : "angekreuzt",
 	    'false'                  : "nicht angekreuzt",
@@ -256,6 +257,7 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 	    'mustBeUnchecked'        : " must be unchecked",
 	    'mustBeUnselected'       : " must not be selected",
 	    'mustBeUnmarked'         : " must not be marked",
+	    'selectOneMultipleSelectionIds' : "must return at most one selection id (got %d)",
 
 	    'true'                   : "checked",
 	    'false'                  : "unchecked",
@@ -562,7 +564,17 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 			if (evaluation != null) {
 				inputFieldVariable.oldValue = _cloneJSON(inputFieldVariable.value);
 				inputFieldVariable.valueErrorMessage = evaluation.errorMessage;
-				_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+				if (evaluation.errorMessage == null || evaluation.errorMessage.length == 0) {
+					try {
+						_setInputFieldVariableValue(inputFieldVariable.value, evaluation.returnValue);
+					} catch (e) {
+						if (_testPropertyExists(e, 'msg')) {
+							inputFieldVariable.valueErrorMessage = e.msg;
+						} else {
+							inputFieldVariable.valueErrorMessage = "value expression " + inputFieldVariable.value.jsVariableName + ": " + e.toString();
+						}
+					}
+				}
 			}
 
 			inputFieldVariable.processed = true;
@@ -1642,6 +1654,15 @@ var FIELD_CALCULATION_OVERRIDE_CALCULATED_VALUES = true;
 							newValue[i] = newValue[i];
 						}
 					}
+				}
+				if ((inputFieldVariableValue.inputFieldType == "SELECT_ONE_DROPDOWN"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_H"
+						|| inputFieldVariableValue.inputFieldType == "SELECT_ONE_RADIO_V")
+						&& newValue.length > 1) {
+					var locale = (inputFieldVars.locale != null && (inputFieldVars.locale in localizedMessages)) ? inputFieldVars.locale : defaultLocale;
+					var detail = sprintf(localizedMessages[locale]['selectOneMultipleSelectionIds'], newValue.length);
+					var variableName = inputFieldVariableValue.jsVariableName;
+					throw { msg: (variableName != null && variableName.length > 0) ? ("value expression " + variableName + ": " + detail) : detail };
 				}
 				inputFieldVariableValue.selectionValueIds = newValue;
 				break;

--- a/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/inquiry.js
+++ b/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/inquiry.js
@@ -889,7 +889,7 @@ function setSelectOneRadioVal(inquiryId,selectionValueIds) {
 }
 
 function getSelectOneRadioVal(inquiryId) {
-    var elems = $('[id^="' + inquiryId + '_"] input[type="radio"');
+    var elems = $('[id^="' + inquiryId + '_"] input[type="radio"]');
     var result = [];
     elems.each(function(index, elem) {
         if ($(this).puiradiobutton('isChecked')) {

--- a/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/inquiry.js
+++ b/CTSMS/BulkProcessor/Projects/WebApps/Signup/public/js/inquiry.js
@@ -765,10 +765,10 @@ function _initSelectOneDropdown(context,value,content) {
 function setSelectOneDropdownVal(inquiryId,selectionValueIds) {
 
     var elem = $('#' + inquiryId + '_select_one_dropdown');
+    // apply calculated value returns selection id array; [] / null => clear
+    // option values are strings; calculated selection ids may be numbers
     if (selectionValueIds != null && selectionValueIds.length > 0) {
-        for (var i = 0; i < selectionValueIds.length; i++) {
-            elem.puidropdown('selectValue',selectionValueIds[i]);
-        }
+        elem.puidropdown('selectValue', '' + selectionValueIds[0]);
     } else {
         elem.puidropdown('selectValue','');
     }
@@ -866,12 +866,26 @@ function _initSelectOneRadio(context,value,content) {
 
 }
 function setSelectOneRadioVal(inquiryId,selectionValueIds) {
-    if (selectionValueIds != null) {
-        for (var i = 0; i < selectionValueIds.length; i++) {
-            $('#' + inquiryId + '_' + selectionValueIds[i] + '_select_one_radio').puiradiobutton('check');
-
+    // apply calculated value returns selection id array; [] / null => clear
+    // option values are strings; calculated selection ids may be numbers
+    var id = (selectionValueIds != null && selectionValueIds.length > 0)
+        ? selectionValueIds[0] : null;
+    var elems = $('[id^="' + inquiryId + '_"] input[type="radio"]');
+    elems.each(function() {
+        var input = $(this);
+        var match = (id != null && id !== '' && input.val() == id);
+        if (match) {
+            input.puiradiobutton('check');
+        } else if (input.puiradiobutton('isChecked')) {
+            // must clear other inputs; otherwise several stay checked and getValue()
+            // returns the first (wrong) id — breaks valueEquals / delta after manual change
+            // (puiradiobutton has no uncheck API)
+            input.prop('checked', false);
+            input.closest('.ui-radiobutton').children('.ui-radiobutton-box')
+                .removeClass('ui-state-active ui-state-focus ui-state-hover')
+                .children('.ui-radiobutton-icon').removeClass('fa fa-fw fa-circle');
         }
-    }
+    });
 }
 
 function getSelectOneRadioVal(inquiryId) {
@@ -956,13 +970,18 @@ function _initSelectMany(context,value,content) {
 function setSelectManyVal(inquiryId,selectionValueIds) {
 
     var elems = $('[id^="' + inquiryId + '_"] input[type="checkbox"]');
+    // apply calculated value may pass null; treat as clear
+    if (selectionValueIds == null) {
+        selectionValueIds = [];
+    }
     var ids = {};
-    if (selectionValueIds != null && selectionValueIds instanceof Array) {
+    if (selectionValueIds instanceof Array) {
         for (var i = 0; i < selectionValueIds.length; i++) {
             if (selectionValueIds[i] instanceof Array) {
                 throw new Error('value element is an array');
             }
-            ids[selectionValueIds[i]] = 1;
+            // option values are strings; calculated selection ids may be numbers
+            ids['' + selectionValueIds[i]] = 1;
         }
     }
     elems.each(function(index, elem) {


### PR DESCRIPTION
Port CTSMS cursor/select-one-setvalue-and-multi-id-error: validate select-one calculated ids, propagate set errors, and clear/coerce selection widget values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of calculated field values, with clearer error messages when processing fails.
  * Prevented multiple selections from being assigned to single-select dropdowns and radio buttons.
  * Fixed clearing and value matching for dropdowns, radio buttons, and checkboxes.
  * Improved compatibility when selection values are provided as numbers or text.

* **Localization**
  * Added German and English messages for invalid multiple selections in single-select fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->