### PR TITLE
Ensure ETL job scripts report final status and release lock files.

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -62,7 +62,7 @@ use CTSMS::BulkProcessor::LoadConfig qw(
     $ANY_CONFIG_TYPE
 );
 use CTSMS::BulkProcessor::Array qw(removeduplicates);
-use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning);
+use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning releaselock);
 use CTSMS::BulkProcessor::Mail qw(
     cleanupmsgfiles
 );
@@ -280,7 +280,9 @@ sub main {
                 scripterror("unknown task option '" . $task . "', must be one of " . join(', ',@TASK_OPTS),getlogger(getscriptpath()));
                 last;
             }
-            update_job($PROCESSING_JOB_STATUS);
+            eval {
+                update_job($PROCESSING_JOB_STATUS);
+            };
         }
         destroy_all_dbs();
     } else {
@@ -289,20 +291,27 @@ sub main {
     }
 
     push(@attachmentfiles,$attachmentlogfile);
-    $cli = 1;
-    if ($result and $completion) {
-        if ($upload_files) {
-            push(@messages,"Visit $ctsms_base_url/trial/trial.jsf?trialid=$ecrf_data_trial_id to download files.");
-        }
-        completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } elsif ($result) {
-        done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } else {
-        scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
-        update_job($FAILED_JOB_STATUS);
+    my $final_status = $result ? $OK_JOB_STATUS : $FAILED_JOB_STATUS;
+    eval {
+        update_job($final_status);
+    };
+    if (my $err = $@) {
+        scriptwarn('update_job failed: ' . $err,getlogger(getscriptpath()));
     }
+    $cli = 1;
+    eval {
+        if ($result and $completion) {
+            if ($upload_files) {
+                push(@messages,"Visit $ctsms_base_url/trial/trial.jsf?trialid=$ecrf_data_trial_id to download files.");
+            }
+            completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } elsif ($result) {
+            done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } else {
+            scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
+        }
+    };
+    releaselock();
 
     return $result;
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -63,7 +63,7 @@ use CTSMS::BulkProcessor::LoadConfig qw(
     $ANY_CONFIG_TYPE
 );
 use CTSMS::BulkProcessor::Array qw(removeduplicates);
-use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning);
+use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning releaselock);
 use CTSMS::BulkProcessor::Mail qw(
     cleanupmsgfiles
 );
@@ -181,7 +181,9 @@ sub main {
                 scripterror("unknown task option '" . $task . "', must be one of " . join(', ',@TASK_OPTS),getlogger(getscriptpath()));
                 last;
             }
-            update_job($PROCESSING_JOB_STATUS);
+            eval {
+                update_job($PROCESSING_JOB_STATUS);
+            };
         }
         destroy_all_dbs();
     } else {
@@ -190,17 +192,24 @@ sub main {
     }
 
     push(@attachmentfiles,$attachmentlogfile);
-    $cli = 1;
-    if ($result and $completion) {
-        completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } elsif ($result) {
-        done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } else {
-        scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
-        update_job($FAILED_JOB_STATUS);
+    my $final_status = $result ? $OK_JOB_STATUS : $FAILED_JOB_STATUS;
+    eval {
+        update_job($final_status);
+    };
+    if (my $err = $@) {
+        scriptwarn('update_job failed: ' . $err,getlogger(getscriptpath()));
     }
+    $cli = 1;
+    eval {
+        if ($result and $completion) {
+            completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } elsif ($result) {
+            done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } else {
+            scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
+        }
+    };
+    releaselock();
 
     return $result;
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -61,7 +61,7 @@ use CTSMS::BulkProcessor::LoadConfig qw(
     $ANY_CONFIG_TYPE
 );
 use CTSMS::BulkProcessor::Array qw(removeduplicates);
-use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning);
+use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning releaselock);
 use CTSMS::BulkProcessor::Mail qw(
     cleanupmsgfiles
 );
@@ -217,7 +217,9 @@ sub main {
                 scripterror("unknown task option '" . $task . "', must be one of " . join(', ',@TASK_OPTS),getlogger(getscriptpath()));
                 last;
             }
-            update_job($PROCESSING_JOB_STATUS);
+            eval {
+                update_job($PROCESSING_JOB_STATUS);
+            };
         }
         destroy_all_dbs();
     } else {
@@ -226,20 +228,27 @@ sub main {
     }
 
     push(@attachmentfiles,$attachmentlogfile);
-    $cli = 1;
-    if ($result and $completion) {
-        if ($upload_files) {
-            push(@messages,"Visit $ctsms_base_url/trial/trial.jsf?trialid=$inquiry_trial_id to download files.");
-        }
-        completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } elsif ($result) {
-        done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } else {
-        scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
-        update_job($FAILED_JOB_STATUS);
+    my $final_status = $result ? $OK_JOB_STATUS : $FAILED_JOB_STATUS;
+    eval {
+        update_job($final_status);
+    };
+    if (my $err = $@) {
+        scriptwarn('update_job failed: ' . $err,getlogger(getscriptpath()));
     }
+    $cli = 1;
+    eval {
+        if ($result and $completion) {
+            if ($upload_files) {
+                push(@messages,"Visit $ctsms_base_url/trial/trial.jsf?trialid=$inquiry_trial_id to download files.");
+            }
+            completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } elsif ($result) {
+            done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } else {
+            scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
+        }
+    };
+    releaselock();
 
     return $result;
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -63,7 +63,7 @@ use CTSMS::BulkProcessor::LoadConfig qw(
     $ANY_CONFIG_TYPE
 );
 use CTSMS::BulkProcessor::Array qw(removeduplicates);
-use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning);
+use CTSMS::BulkProcessor::Utils qw(getscriptpath prompt cleanupdir checkrunning releaselock);
 use CTSMS::BulkProcessor::Mail qw(
     cleanupmsgfiles
 );
@@ -181,7 +181,9 @@ sub main {
                 scripterror("unknown task option '" . $task . "', must be one of " . join(', ',@TASK_OPTS),getlogger(getscriptpath()));
                 last;
             }
-            update_job($PROCESSING_JOB_STATUS);
+            eval {
+                update_job($PROCESSING_JOB_STATUS);
+            };
         }
         destroy_all_dbs();
     } else {
@@ -190,17 +192,24 @@ sub main {
     }
 
     push(@attachmentfiles,$attachmentlogfile);
-    $cli = 1;
-    if ($result and $completion) {
-        completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } elsif ($result) {
-        done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
-        update_job($OK_JOB_STATUS);
-    } else {
-        scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
-        update_job($FAILED_JOB_STATUS);
+    my $final_status = $result ? $OK_JOB_STATUS : $FAILED_JOB_STATUS;
+    eval {
+        update_job($final_status);
+    };
+    if (my $err = $@) {
+        scriptwarn('update_job failed: ' . $err,getlogger(getscriptpath()));
     }
+    $cli = 1;
+    eval {
+        if ($result and $completion) {
+            completion(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } elsif ($result) {
+            done(join("\n\n",@messages),\@attachmentfiles,getlogger(getscriptpath()));
+        } else {
+            scriptwarn(join("\n\n",@messages),getlogger(getscriptpath()),1);
+        }
+    };
+    releaselock();
 
     return $result;
 }

--- a/CTSMS/BulkProcessor/Utils.pm
+++ b/CTSMS/BulkProcessor/Utils.pm
@@ -1213,14 +1213,12 @@ sub checkrunning {
 
 sub releaselock {
     my $fh = $_lock_fh;
-    my $path = $_lock_path;
     $_lock_fh = undef;
     $_lock_path = undef;
     if ($fh) {
         flock($fh, LOCK_UN);
         close($fh);
     }
-    unlink($path) if defined $path and length($path);
 }
 
 END {

--- a/CTSMS/BulkProcessor/Utils.pm
+++ b/CTSMS/BulkProcessor/Utils.pm
@@ -8,7 +8,7 @@ use threads;
 use POSIX qw(strtod locale_h floor fmod);
 setlocale(LC_NUMERIC, 'C');
 
-use Fcntl qw(LOCK_EX LOCK_NB);
+use Fcntl qw(LOCK_EX LOCK_NB LOCK_UN);
 use Data::UUID qw();
 use Net::Address::IP::Local qw();
 use Net::Domain qw(hostname hostfqdn hostdomain);
@@ -107,6 +107,7 @@ our @EXPORT_OK = qw(
     excel_to_timestamp
 
     checkrunning
+    releaselock
     unshare
 
     load_module
@@ -1185,21 +1186,45 @@ sub run {
 }
 
 #https://www.perlmonks.org/?node_id=590619
+my $_lock_fh;
+my $_lock_path;
+
 sub checkrunning {
 
     my ($lockfile,$errorcode,$logger) = @_;
-    if (not open (LOCKFILE, '>' . $lockfile)) {
+    releaselock();
+    my $fh;
+    if (not open($fh, '>', $lockfile)) {
       if (defined $errorcode and ref $errorcode eq 'CODE') {
         return &$errorcode('cannot open file ' . $lockfile . ': ' . $!,$logger);
       }
       return 0;
     } else {
-      unless (flock(LOCKFILE, LOCK_EX|LOCK_NB)) {
+      unless (flock($fh, LOCK_EX|LOCK_NB)) {
+        close($fh);
         return &$errorcode('program already running',$logger);
       }
+      $_lock_fh = $fh;
+      $_lock_path = $lockfile;
       return 1;
     }
 
+}
+
+sub releaselock {
+    my $fh = $_lock_fh;
+    my $path = $_lock_path;
+    $_lock_fh = undef;
+    $_lock_path = undef;
+    if ($fh) {
+        flock($fh, LOCK_UN);
+        close($fh);
+    }
+    unlink($path) if defined $path and length($path);
+}
+
+END {
+    releaselock();
 }
 
 sub unshare {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of ETL import and export jobs when status updates or completion reporting encounter errors.
  * Job processing now continues gracefully when intermediate status updates fail.
  * Final job outcomes are recorded consistently as successful or failed.

* **Reliability**
  * Added automatic process-lock cleanup to prevent stale locks from blocking subsequent jobs.
  * Locks are released during normal completion and unexpected program termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->