### PR TITLE
Add unblinded Proband create/update from import identity columns

### DIFF
--- a/CTSMS/BulkProcessor/ConnectorPool.pm
+++ b/CTSMS/BulkProcessor/ConnectorPool.pm
@@ -100,6 +100,17 @@ sub get_ctsms_restapi {
     if (!defined $ctsms_restapis->{$name}) {
         $ctsms_restapis->{$name} = CTSMS::BulkProcessor::RestConnectors::CtsmsRestApi->new($instance_name);
         $ctsms_restapis->{$name}->setup($uri // $ctsmsrestapi_uri,$username // $ctsmsrestapi_username,$password // $ctsmsrestapi_password,$realm // $ctsmsrestapi_realm);
+        # Worker threads get a fresh connector keyed by tid. Inherit JWT from any
+        # already-configured connector in this interpreter (ithreads clone the
+        # root connector that received --auth before workers were spawned).
+        foreach my $api (values %$ctsms_restapis) {
+            next unless defined $api and $api != $ctsms_restapis->{$name};
+            my $jwt = $api->jwt();
+            if (defined $jwt and length($jwt)) {
+                $ctsms_restapis->{$name}->jwt($jwt);
+                last;
+            }
+        }
     }
     return $ctsms_restapis->{$name};
 

--- a/CTSMS/BulkProcessor/ConnectorPool.pm
+++ b/CTSMS/BulkProcessor/ConnectorPool.pm
@@ -98,22 +98,36 @@ sub get_ctsms_restapi {
     my ($instance_name,$uri,$username,$password,$realm) = @_;
     my $name = get_connectorinstancename($instance_name);
     if (!defined $ctsms_restapis->{$name}) {
-        $ctsms_restapis->{$name} = CTSMS::BulkProcessor::RestConnectors::CtsmsRestApi->new($instance_name);
-        $ctsms_restapis->{$name}->setup($uri // $ctsmsrestapi_uri,$username // $ctsmsrestapi_username,$password // $ctsmsrestapi_password,$realm // $ctsmsrestapi_realm);
-        # Worker threads get a fresh connector keyed by tid. Inherit JWT from any
-        # already-configured connector in this interpreter (ithreads clone the
-        # root connector that received --auth before workers were spawned).
-        foreach my $api (values %$ctsms_restapis) {
-            next unless defined $api and $api != $ctsms_restapis->{$name};
-            my $jwt = $api->jwt();
+        my $api = CTSMS::BulkProcessor::RestConnectors::CtsmsRestApi->new($instance_name);
+        $api->setup($uri // $ctsmsrestapi_uri,$username // $ctsmsrestapi_username,$password // $ctsmsrestapi_password,$realm // $ctsmsrestapi_realm);
+        $ctsms_restapis->{$name} = $api;
+        # Worker threads get a fresh connector keyed by tid. Inherit JWT only from
+        # a connector already configured with the same auth context (ithreads clone
+        # the root connector that received --auth before workers were spawned).
+        # Do not copy JWT across site/lang credentials (get_ctsms_site_lang_restapi).
+        foreach my $other (values %$ctsms_restapis) {
+            next unless defined $other and $other != $api;
+            next unless _ctsms_restapi_auth_matches($api,$other);
+            my $jwt = $other->jwt();
             if (defined $jwt and length($jwt)) {
-                $ctsms_restapis->{$name}->jwt($jwt);
+                $api->jwt($jwt);
                 last;
             }
         }
     }
     return $ctsms_restapis->{$name};
 
+}
+
+sub _ctsms_restapi_auth_matches {
+    my ($a,$b) = @_;
+    return 0 unless defined $a and defined $b;
+    return 0 unless ($a->{username} // '') eq ($b->{username} // '');
+    return 0 unless ($a->{password} // '') eq ($b->{password} // '');
+    return 0 unless ($a->{realm} // '') eq ($b->{realm} // '');
+    my $a_uri = defined $a->{uri} ? "$a->{uri}" : '';
+    my $b_uri = defined $b->{uri} ? "$b->{uri}" : '';
+    return $a_uri eq $b_uri;
 }
 
 sub get_ctsms_restapi_last_error {

--- a/CTSMS/BulkProcessor/LogError.pm
+++ b/CTSMS/BulkProcessor/LogError.pm
@@ -481,7 +481,7 @@ sub rowprocessingerror {
 
     my ($tid, $message, $logger) = @_;
     if (defined $logger) {
-        $logger->error(($enablemultithreading ? '[' . $tid . '] ' : '') . $message);
+        $logger->error((($enablemultithreading and defined $tid) ? '[' . $tid . '] ' : '') . $message);
     }
     terminate($message, $logger);
 
@@ -491,7 +491,7 @@ sub rowprocessingwarn {
 
     my ($tid, $message, $logger) = @_;
     if (defined $logger) {
-        $logger->warn(($enablemultithreading ? '[' . $tid . '] ' : '') . $message);
+        $logger->warn((($enablemultithreading and defined $tid) ? '[' . $tid . '] ' : '') . $message);
     }
     warning($message, $logger);
 

--- a/CTSMS/BulkProcessor/Logging.pm
+++ b/CTSMS/BulkProcessor/Logging.pm
@@ -186,7 +186,7 @@ sub init_log {
                "log4perl.appender.ScreenApp           = Log::Log4perl::Appender::Screen\n" .
                "log4perl.appender.ScreenApp.utf8      = 1\n" .
                'log4perl.appender.ScreenApp.Threshold = ' . $screenloglevel . "\n" .
-               "log4perl.appender.ScreenApp.stderr    = ' . $screenlogstderr . \n" .
+               'log4perl.appender.ScreenApp.stderr    = ' . $screenlogstderr . "\n" .
                "log4perl.appender.ScreenApp.layout    = Log::Log4perl::Layout::SimpleLayout\n" .
                'log4perl.appender.ScreenApp.layout.ConversionPattern = %d> %m%n';
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -194,8 +194,12 @@ sub init {
             input_path => $input_path,
         );
     };
-    if ($@) {
+    if (my $err = $@) {
         $result = 0;
+        # terminate()/scripterror croak inside the eval above; re-surface so the
+        # console still shows the failure (e.g. invalid --id / trial id).
+        chomp($err);
+        warn($err . "\n");
         eval {
             update_job($FAILED_JOB_STATUS);
         };

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
@@ -168,6 +168,8 @@ my $header_rownum :shared = 0;
 my $registration :shared;
 my $warning_count :shared = 0;
 my $value_count :shared = 0;
+# listentry ids already cleared this import run (shared across sheets/threads)
+my %ecrf_cleared_listentries :shared = ();
 
 my $comment_char = '#';
 
@@ -276,6 +278,8 @@ sub import_ecrf_data_horizontal {
         $warning_count = 0;
         lock $value_count;
         $value_count = 0;
+        lock %ecrf_cleared_listentries;
+        %ecrf_cleared_listentries = ();
     }
 
     my $static_context = {};
@@ -671,56 +675,83 @@ sub _clear_ecrf {
     my $result = 1;
     my $listentry_id = $context->{probandlistentry}->{id};
 
-    $context->{clear_map} = {};
+    $context->{clear_map} //= {};
 
-    if (not $context->{listentry_created}
-        and ($clear_sections or $clear_all_sections)
-        and not exists $context->{clear_map}->{$listentry_id}) {
-        my $columns = [];
-        $columns = $context->{all_columns} if $clear_all_sections;
-        $columns = $context->{columns} if $clear_sections;
-        my $removed_value_count = 0;
+    return $result unless (not $context->{listentry_created}
+        and ($clear_sections or $clear_all_sections));
 
-        $context->{clear_map}->{$listentry_id} = {};
-        foreach my $column (@$columns) {
-            #$context->{clear_map}->{$listentry_id} //= {};
-
-            next unless _get_ecrffieldvalue_editable($context,$column->{colname});
-
-            my $ecrf_id = $column->{ecrffield}->{ecrf}->{id};
-            $context->{clear_map}->{$listentry_id}->{$ecrf_id} //= {};
-            my $section_map = $context->{clear_map}->{$listentry_id}->{$ecrf_id};
-
-            my $visit_id = undef;
-            $visit_id = $column->{visit}->{id} if $column->{visit};
-            if (defined $visit_id) {
-                $context->{clear_map}->{$listentry_id}->{$ecrf_id}->{$visit_id} //= {};
-                $section_map = $context->{clear_map}->{$listentry_id}->{$ecrf_id}->{$visit_id};
-                next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}
-                    and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}->{valueLockdown});
-            } else {
-                next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}
-                    and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}->{valueLockdown});
+    # clear_all_sections: wipe once per listentry for the whole import (all sheets/threads).
+    # clear_sections: clear each eCRF/visit/section the first time it is seen for that listentry.
+    if ($clear_all_sections) {
+        {
+            lock %ecrf_cleared_listentries;
+            if (exists $ecrf_cleared_listentries{$listentry_id}
+                or exists $context->{clear_map}->{$listentry_id}) {
+                return $result;
             }
-
-            my $section = ($column->{ecrffield}->{section} // '');
-            unless (exists $section_map->{$section}) {
-                my $values;
-                my $section_label = "eCRF '$column->{ecrffield}->{ecrf}->{name}" . (defined $column->{visit} ? '@' . $column->{visit}->{token} : '') . "' section '" . $section . "'";
-                eval {
-                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValue::clear($listentry_id, $ecrf_id, $visit_id, $section);
-                };
-                if ($@) {
-                    _warn_or_error($context,"error deleting $section_label values: " . $@);
-                    $result = 0;
-                } else {
-                    _info($context,"$section_label values deleted",1);
-                }
-                $section_map->{$section} = $values;
-                $removed_value_count += scalar @$values;
-            }
+            $ecrf_cleared_listentries{$listentry_id} = 1;
+            $context->{clear_map}->{$listentry_id} = 1;
         }
-        _info($context,"$removed_value_count eCRF values deleted");
+    } else {
+        $context->{clear_map}->{$listentry_id} //= {};
+    }
+
+    my $columns = [];
+    $columns = $context->{all_columns} if $clear_all_sections;
+    $columns = $context->{columns} if $clear_sections;
+    my $removed_value_count = 0;
+    my %section_done = ();
+
+    foreach my $column (@$columns) {
+        next unless _get_ecrffieldvalue_editable($context,$column->{colname});
+
+        my $ecrf_id = $column->{ecrffield}->{ecrf}->{id};
+        my $visit_id = undef;
+        $visit_id = $column->{visit}->{id} if $column->{visit};
+        if (defined $visit_id) {
+            next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}
+                and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}->{valueLockdown});
+        } else {
+            next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}
+                and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}->{valueLockdown});
+        }
+
+        my $section = ($column->{ecrffield}->{section} // '');
+        my $section_key = join("\t", $ecrf_id, ($visit_id // ''), $section);
+        if ($clear_all_sections) {
+            next if exists $section_done{$section_key};
+        } else {
+            my $section_map = $context->{clear_map}->{$listentry_id};
+            $section_map->{$ecrf_id} //= {};
+            $section_map = $section_map->{$ecrf_id};
+            if (defined $visit_id) {
+                $section_map->{$visit_id} //= {};
+                $section_map = $section_map->{$visit_id};
+            }
+            next if exists $section_map->{$section};
+            $section_map->{$section} = 1;
+        }
+
+        my $values;
+        my $section_label = "eCRF '$column->{ecrffield}->{ecrf}->{name}" . (defined $column->{visit} ? '@' . $column->{visit}->{token} : '') . "' section '" . $section . "'";
+        eval {
+            $values = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValue::clear($listentry_id, $ecrf_id, $visit_id, $section);
+        };
+        if ($@) {
+            _warn_or_error($context,"error deleting $section_label values: " . $@);
+            $result = 0;
+        } else {
+            _info($context,"$section_label values deleted",1);
+            $removed_value_count += scalar @{$values // []};
+        }
+        $section_done{$section_key} = 1 if $clear_all_sections;
+    }
+    _info($context,"$removed_value_count eCRF values deleted");
+
+    if ($clear_all_sections and not $result) {
+        lock %ecrf_cleared_listentries;
+        delete $ecrf_cleared_listentries{$listentry_id};
+        delete $context->{clear_map}->{$listentry_id};
     }
     return $result;
 
@@ -732,7 +763,7 @@ sub _load_ecrf_status {
 
     my $listentry_id = $context->{probandlistentry}->{id};
 
-    $context->{ecrfstatus_map} = {};
+    $context->{ecrfstatus_map} //= {};
 
     if (not exists $context->{ecrfstatus_map}->{$listentry_id}) {
         my $columns = $context->{columns};

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
@@ -28,6 +28,9 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
     $ecrf_proband_alias_column_name
     $ecrf_proband_category_column_name
     $ecrf_proband_department_column_name
+    $ecrf_proband_first_name_column_name
+    $ecrf_proband_last_name_column_name
+    $ecrf_proband_date_of_birth_column_name
     $ecrf_proband_gender_column_name
 
     get_proband_columns
@@ -132,6 +135,10 @@ use CTSMS::BulkProcessor::Projects::ETL::Import qw(
     get_values_stats
     
     get_proband_in
+    read_proband_particulars
+    proband_particulars_complete
+    any_proband_particular_present
+    build_proband_particulars_update
     
     init_context
     get_log_label
@@ -853,12 +860,16 @@ sub _register_proband {
                 _warn_or_error($context,"error loading proband: " . $@);
                 $result = 0;
             } elsif ((scalar @$probands) == 0) {
+                my $particulars = read_proband_particulars($context,
+                    $ecrf_proband_first_name_column_name,$ecrf_proband_last_name_column_name,
+                    $ecrf_proband_date_of_birth_column_name,$ecrf_proband_gender_column_name);
                 if (defined $id) {
                     _warn_or_error($context,"cannot find proband id " . $id);
                     $result = 0;
                 } elsif (defined $alias) {
                     eval {
-                         my $in = get_proband_in($context,$alias,$ecrf_proband_category_column_name,$ecrf_proband_department_column_name,$ecrf_proband_gender_column_name);
+                         my $in = get_proband_in($context,$alias,$ecrf_proband_category_column_name,$ecrf_proband_department_column_name,$ecrf_proband_gender_column_name,
+                             $ecrf_proband_first_name_column_name,$ecrf_proband_last_name_column_name,$ecrf_proband_date_of_birth_column_name);
                          $in->{"person"} = ($context->{ecrf_data_trial}->{type}->{person} ? \1 : \0);
                          $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
                     };
@@ -867,6 +878,20 @@ sub _register_proband {
                         $result = 0;
                     } else {
                         _info($context,"proband " . $context->{proband}->alias . " created");
+                        $proband_created = 1;
+                    }
+                } elsif (proband_particulars_complete($particulars)) {
+                    eval {
+                         my $in = get_proband_in($context,undef,$ecrf_proband_category_column_name,$ecrf_proband_department_column_name,$ecrf_proband_gender_column_name,
+                             $ecrf_proband_first_name_column_name,$ecrf_proband_last_name_column_name,$ecrf_proband_date_of_birth_column_name);
+                         $in->{"person"} = ($context->{ecrf_data_trial}->{type}->{person} ? \1 : \0);
+                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                    };
+                    if ($@) {
+                        _warn_or_error($context,"error creating unblinded proband: " . $@);
+                        $result = 0;
+                    } else {
+                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
                         $proband_created = 1;
                     }
                 } else {
@@ -906,6 +931,22 @@ sub _register_proband {
                     _info($context,"proband " . $context->{proband}->alias . " found");
                 }
                 $set_listentrytag_values = $update_listentrytag_values if (defined $id or defined $alias);
+
+                my $particulars = read_proband_particulars($context,
+                    $ecrf_proband_first_name_column_name,$ecrf_proband_last_name_column_name,
+                    $ecrf_proband_date_of_birth_column_name,$ecrf_proband_gender_column_name);
+                my $update_in = build_proband_particulars_update($context->{proband},$particulars);
+                if ($update_in) {
+                    eval {
+                        $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::update_item($update_in);
+                    };
+                    if ($@) {
+                        _warn_or_error($context,"error updating proband particulars: " . $@);
+                        $result = 0;
+                    } else {
+                        _info($context,"proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " particulars updated");
+                    }
+                }
             }
 
             if ($context->{proband} and $context->{proband}->locked) {

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImport.pm
@@ -168,8 +168,6 @@ my $header_rownum :shared = 0;
 my $registration :shared;
 my $warning_count :shared = 0;
 my $value_count :shared = 0;
-# listentry ids already cleared this import run (shared across sheets/threads)
-my %ecrf_cleared_listentries :shared = ();
 
 my $comment_char = '#';
 
@@ -278,8 +276,6 @@ sub import_ecrf_data_horizontal {
         $warning_count = 0;
         lock $value_count;
         $value_count = 0;
-        lock %ecrf_cleared_listentries;
-        %ecrf_cleared_listentries = ();
     }
 
     my $static_context = {};
@@ -675,83 +671,56 @@ sub _clear_ecrf {
     my $result = 1;
     my $listentry_id = $context->{probandlistentry}->{id};
 
-    $context->{clear_map} //= {};
+    $context->{clear_map} = {};
 
-    return $result unless (not $context->{listentry_created}
-        and ($clear_sections or $clear_all_sections));
+    if (not $context->{listentry_created}
+        and ($clear_sections or $clear_all_sections)
+        and not exists $context->{clear_map}->{$listentry_id}) {
+        my $columns = [];
+        $columns = $context->{all_columns} if $clear_all_sections;
+        $columns = $context->{columns} if $clear_sections;
+        my $removed_value_count = 0;
 
-    # clear_all_sections: wipe once per listentry for the whole import (all sheets/threads).
-    # clear_sections: clear each eCRF/visit/section the first time it is seen for that listentry.
-    if ($clear_all_sections) {
-        {
-            lock %ecrf_cleared_listentries;
-            if (exists $ecrf_cleared_listentries{$listentry_id}
-                or exists $context->{clear_map}->{$listentry_id}) {
-                return $result;
-            }
-            $ecrf_cleared_listentries{$listentry_id} = 1;
-            $context->{clear_map}->{$listentry_id} = 1;
-        }
-    } else {
-        $context->{clear_map}->{$listentry_id} //= {};
-    }
+        $context->{clear_map}->{$listentry_id} = {};
+        foreach my $column (@$columns) {
+            #$context->{clear_map}->{$listentry_id} //= {};
 
-    my $columns = [];
-    $columns = $context->{all_columns} if $clear_all_sections;
-    $columns = $context->{columns} if $clear_sections;
-    my $removed_value_count = 0;
-    my %section_done = ();
+            next unless _get_ecrffieldvalue_editable($context,$column->{colname});
 
-    foreach my $column (@$columns) {
-        next unless _get_ecrffieldvalue_editable($context,$column->{colname});
+            my $ecrf_id = $column->{ecrffield}->{ecrf}->{id};
+            $context->{clear_map}->{$listentry_id}->{$ecrf_id} //= {};
+            my $section_map = $context->{clear_map}->{$listentry_id}->{$ecrf_id};
 
-        my $ecrf_id = $column->{ecrffield}->{ecrf}->{id};
-        my $visit_id = undef;
-        $visit_id = $column->{visit}->{id} if $column->{visit};
-        if (defined $visit_id) {
-            next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}
-                and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}->{valueLockdown});
-        } else {
-            next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}
-                and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}->{valueLockdown});
-        }
-
-        my $section = ($column->{ecrffield}->{section} // '');
-        my $section_key = join("\t", $ecrf_id, ($visit_id // ''), $section);
-        if ($clear_all_sections) {
-            next if exists $section_done{$section_key};
-        } else {
-            my $section_map = $context->{clear_map}->{$listentry_id};
-            $section_map->{$ecrf_id} //= {};
-            $section_map = $section_map->{$ecrf_id};
+            my $visit_id = undef;
+            $visit_id = $column->{visit}->{id} if $column->{visit};
             if (defined $visit_id) {
-                $section_map->{$visit_id} //= {};
-                $section_map = $section_map->{$visit_id};
+                $context->{clear_map}->{$listentry_id}->{$ecrf_id}->{$visit_id} //= {};
+                $section_map = $context->{clear_map}->{$listentry_id}->{$ecrf_id}->{$visit_id};
+                next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}
+                    and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{$visit_id}->{status}->{valueLockdown});
+            } else {
+                next if ($context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}
+                    and $context->{ecrfstatus_map}->{$listentry_id}->{$ecrf_id}->{status}->{valueLockdown});
             }
-            next if exists $section_map->{$section};
-            $section_map->{$section} = 1;
-        }
 
-        my $values;
-        my $section_label = "eCRF '$column->{ecrffield}->{ecrf}->{name}" . (defined $column->{visit} ? '@' . $column->{visit}->{token} : '') . "' section '" . $section . "'";
-        eval {
-            $values = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValue::clear($listentry_id, $ecrf_id, $visit_id, $section);
-        };
-        if ($@) {
-            _warn_or_error($context,"error deleting $section_label values: " . $@);
-            $result = 0;
-        } else {
-            _info($context,"$section_label values deleted",1);
-            $removed_value_count += scalar @{$values // []};
+            my $section = ($column->{ecrffield}->{section} // '');
+            unless (exists $section_map->{$section}) {
+                my $values;
+                my $section_label = "eCRF '$column->{ecrffield}->{ecrf}->{name}" . (defined $column->{visit} ? '@' . $column->{visit}->{token} : '') . "' section '" . $section . "'";
+                eval {
+                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValue::clear($listentry_id, $ecrf_id, $visit_id, $section);
+                };
+                if ($@) {
+                    _warn_or_error($context,"error deleting $section_label values: " . $@);
+                    $result = 0;
+                } else {
+                    _info($context,"$section_label values deleted",1);
+                }
+                $section_map->{$section} = $values;
+                $removed_value_count += scalar @$values;
+            }
         }
-        $section_done{$section_key} = 1 if $clear_all_sections;
-    }
-    _info($context,"$removed_value_count eCRF values deleted");
-
-    if ($clear_all_sections and not $result) {
-        lock %ecrf_cleared_listentries;
-        delete $ecrf_cleared_listentries{$listentry_id};
-        delete $context->{clear_map}->{$listentry_id};
+        _info($context,"$removed_value_count eCRF values deleted");
     }
     return $result;
 
@@ -763,7 +732,7 @@ sub _load_ecrf_status {
 
     my $listentry_id = $context->{probandlistentry}->{id};
 
-    $context->{ecrfstatus_map} //= {};
+    $context->{ecrfstatus_map} = {};
 
     if (not exists $context->{ecrfstatus_map}->{$listentry_id}) {
         my $columns = $context->{columns};

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -142,8 +142,12 @@ sub init {
             input_path => $input_path,
         );
     };
-    if ($@) {
+    if (my $err = $@) {
         $result = 0;
+        # terminate()/scripterror croak inside the eval above; re-surface so the
+        # console still shows the failure (e.g. invalid --id / trial id).
+        chomp($err);
+        warn($err . "\n");
         eval {
             update_job($FAILED_JOB_STATUS);
         };

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
@@ -84,6 +84,9 @@ our @EXPORT_OK = qw(
     $ecrf_proband_alias_column_name
     $ecrf_proband_category_column_name
     $ecrf_proband_department_column_name
+    $ecrf_proband_first_name_column_name
+    $ecrf_proband_last_name_column_name
+    $ecrf_proband_date_of_birth_column_name
     $ecrf_proband_gender_column_name
 
     $ecrf_probandlistentry_group_column_name
@@ -118,6 +121,9 @@ our $timezone = undef;
 our $ecrf_proband_alias_column_name = 'alias';
 our $ecrf_proband_category_column_name;
 our $ecrf_proband_department_column_name;
+our $ecrf_proband_first_name_column_name;
+our $ecrf_proband_last_name_column_name;
+our $ecrf_proband_date_of_birth_column_name;
 our $ecrf_proband_gender_column_name;
 
 our $ecrf_probandlistentry_group_column_name; #subject_group
@@ -270,6 +276,9 @@ sub update_settings {
         $ecrf_proband_alias_column_name = $data->{ecrf_proband_alias_column_name} if exists $data->{ecrf_proband_alias_column_name};
         $ecrf_proband_category_column_name = $data->{ecrf_proband_category_column_name} if exists $data->{ecrf_proband_category_column_name};
         $ecrf_proband_department_column_name = $data->{ecrf_proband_department_column_name} if exists $data->{ecrf_proband_department_column_name};
+        $ecrf_proband_first_name_column_name = $data->{ecrf_proband_first_name_column_name} if exists $data->{ecrf_proband_first_name_column_name};
+        $ecrf_proband_last_name_column_name = $data->{ecrf_proband_last_name_column_name} if exists $data->{ecrf_proband_last_name_column_name};
+        $ecrf_proband_date_of_birth_column_name = $data->{ecrf_proband_date_of_birth_column_name} if exists $data->{ecrf_proband_date_of_birth_column_name};
         $ecrf_proband_gender_column_name = $data->{ecrf_proband_gender_column_name} if exists $data->{ecrf_proband_gender_column_name};
 
         $ecrf_probandlistentry_group_column_name = $data->{ecrf_probandlistentry_group_column_name} if exists $data->{ecrf_probandlistentry_group_column_name};
@@ -325,11 +334,17 @@ sub get_proband_columns {
         push(@columns,$proband->{alias}) if length($ecrf_proband_alias_column_name);
         push(@columns,$proband->{category}->{nameL10nKey}) if length($ecrf_proband_category_column_name);
         push(@columns,$proband->{department}->{nameL10nKey}) if length($ecrf_proband_department_column_name);
+        push(@columns,$proband->{firstName}) if length($ecrf_proband_first_name_column_name);
+        push(@columns,$proband->{lastName}) if length($ecrf_proband_last_name_column_name);
+        push(@columns,$proband->{dateOfBirth}) if length($ecrf_proband_date_of_birth_column_name);
         push(@columns,$proband->{gender}->{sex}) if length($ecrf_proband_gender_column_name);
     } else {
         push(@columns,lc($ecrf_proband_alias_column_name)) if length($ecrf_proband_alias_column_name);
         push(@columns,lc($ecrf_proband_category_column_name)) if length($ecrf_proband_category_column_name);
         push(@columns,lc($ecrf_proband_department_column_name)) if length($ecrf_proband_department_column_name);
+        push(@columns,lc($ecrf_proband_first_name_column_name)) if length($ecrf_proband_first_name_column_name);
+        push(@columns,lc($ecrf_proband_last_name_column_name)) if length($ecrf_proband_last_name_column_name);
+        push(@columns,lc($ecrf_proband_date_of_birth_column_name)) if length($ecrf_proband_date_of_birth_column_name);
         push(@columns,lc($ecrf_proband_gender_column_name)) if length($ecrf_proband_gender_column_name);
     }
     return @columns;

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -409,8 +409,9 @@ sub build_proband_particulars_update {
     my $gender = length($particulars->{gender}) ? $particulars->{gender} : $existing_gender;
     $gender = $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex::NOT_KNOWN unless length($gender);
 
-    # CTSMS rejects dateOfBirth "" (ParseException). Need a real DOB from sheet or existing record.
-    return undef unless length($dob);
+    # Need a complete merged identity before unblinding (CTSMS rejects empty DOB;
+    # names must be present too).
+    return undef unless length($first) and length($last) and length($dob);
 
     my $changed = $was_blinded;
     $changed = 1 if $first ne $existing_first;

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -22,8 +22,6 @@ use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Crit
 
 use CTSMS::BulkProcessor::RestRequests::ctsms::user::UserService::User qw();
 
-use CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband qw();
-
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex qw();
 
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Department qw();
@@ -62,7 +60,6 @@ our @EXPORT_OK = qw(
     
     append_probandalias_criterion
     append_probandid_criterion
-    find_probands_by_particulars
     
     get_values_stats
     
@@ -254,42 +251,6 @@ sub append_probandid_criterion {
         _warn_or_error($context,"empty proband id");
         return 0;
     }
-}
-
-sub find_probands_by_particulars {
-    my ($context,$particulars) = @_;
-    return [] unless $context and proband_particulars_complete($particulars);
-
-    my $dob = $particulars->{dateOfBirth};
-    $dob .= ' 00:00:00' unless $dob =~ /\s/;
-
-    return CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::search({
-        module => $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::DBModule::PROBAND_DB,
-        criterions => [{
-            position => 1,
-            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
-            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.firstNameNormalizedHash'},
-            stringValue => mark_utf8($particulars->{firstName}),
-        },{
-            position => 2,
-            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
-            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
-            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.lastNameNormalizedHash'},
-            stringValue => mark_utf8($particulars->{lastName}),
-        },{
-            position => 3,
-            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
-            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
-            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.dateOfBirthHash'},
-            dateValue => $dob,
-        },{
-            position => 4,
-            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
-            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
-            propertyId => $context->{criterionproperty_map}->{'proband.deferredDelete'},
-            booleanValue => \0,
-        }],
-    });
 }
 
 sub get_values_stats {

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -22,6 +22,8 @@ use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Crit
 
 use CTSMS::BulkProcessor::RestRequests::ctsms::user::UserService::User qw();
 
+use CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband qw();
+
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex qw();
 
 use CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Department qw();
@@ -60,6 +62,7 @@ our @EXPORT_OK = qw(
     
     append_probandalias_criterion
     append_probandid_criterion
+    find_probands_by_particulars
     
     get_values_stats
     
@@ -251,6 +254,42 @@ sub append_probandid_criterion {
         _warn_or_error($context,"empty proband id");
         return 0;
     }
+}
+
+sub find_probands_by_particulars {
+    my ($context,$particulars) = @_;
+    return [] unless $context and proband_particulars_complete($particulars);
+
+    my $dob = $particulars->{dateOfBirth};
+    $dob .= ' 00:00:00' unless $dob =~ /\s/;
+
+    return CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::search({
+        module => $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::DBModule::PROBAND_DB,
+        criterions => [{
+            position => 1,
+            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
+            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.firstNameNormalizedHash'},
+            stringValue => mark_utf8($particulars->{firstName}),
+        },{
+            position => 2,
+            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
+            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
+            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.lastNameNormalizedHash'},
+            stringValue => mark_utf8($particulars->{lastName}),
+        },{
+            position => 3,
+            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
+            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
+            propertyId => $context->{criterionproperty_map}->{'proband.personParticulars.dateOfBirthHash'},
+            dateValue => $dob,
+        },{
+            position => 4,
+            tieId => $context->{criteriontie_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionTie::AND},
+            restrictionId => $context->{criterionrestriction_map}->{$CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::CriterionRestriction::EQ},
+            propertyId => $context->{criterionproperty_map}->{'proband.deferredDelete'},
+            booleanValue => \0,
+        }],
+    });
 }
 
 sub get_values_stats {

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -64,6 +64,10 @@ our @EXPORT_OK = qw(
     get_values_stats
     
     get_proband_in
+    read_proband_particulars
+    proband_particulars_complete
+    any_proband_particular_present
+    build_proband_particulars_update
     
     init_context
     get_log_label
@@ -270,7 +274,8 @@ sub get_values_stats {
 }
 
 sub get_proband_in {
-    my ($context,$alias,$proband_category_column_name,$proband_department_column_name,$proband_gender_column_name) = @_;
+    my ($context,$alias,$proband_category_column_name,$proband_department_column_name,$proband_gender_column_name,
+        $proband_first_name_column_name,$proband_last_name_column_name,$proband_date_of_birth_column_name) = @_;
 
     my $category;
     my $category_col = length($proband_category_column_name) ? lc($proband_category_column_name) : '';
@@ -302,12 +307,11 @@ sub get_proband_in {
     }
     $department = $context->{ctsmsrestapi_user}->{department} unless $department;
 
-    my $gender;
-    my $gender_col = length($proband_gender_column_name) ? lc($proband_gender_column_name) : '';
-    if (length($gender_col)
-        and exists $context->{record}->{$gender_col}) {
-        $gender = $context->{record}->{$gender_col};
-    }
+    my $particulars = read_proband_particulars($context,
+        $proband_first_name_column_name,$proband_last_name_column_name,
+        $proband_date_of_birth_column_name,$proband_gender_column_name);
+
+    my $gender = $particulars->{gender};
     $gender = $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex::NOT_KNOWN unless length($gender);
 
     my %in = (
@@ -318,12 +322,152 @@ sub get_proband_in {
         "gender" => $gender,
         "alias" => $alias,
     );
+    if (proband_particulars_complete($particulars)) {
+        $in{blinded} = \0;
+        $in{firstName} = $particulars->{firstName};
+        $in{lastName} = $particulars->{lastName};
+        $in{dateOfBirth} = $particulars->{dateOfBirth};
+        $in{gender} = $particulars->{gender};
+    }
     #if (EXPR) {
     #    $in{comment} = xxx
     #}
 
     return \%in;
 
+}
+
+sub read_proband_particulars {
+    my ($context,$proband_first_name_column_name,$proband_last_name_column_name,
+        $proband_date_of_birth_column_name,$proband_gender_column_name) = @_;
+
+    my %particulars = (
+        firstName => '',
+        lastName => '',
+        dateOfBirth => '',
+        gender => '',
+    );
+
+    my $first_col = length($proband_first_name_column_name) ? lc($proband_first_name_column_name) : '';
+    if (length($first_col) and exists $context->{record}->{$first_col}) {
+        $particulars{firstName} = trim($context->{record}->{$first_col} // '');
+    }
+
+    my $last_col = length($proband_last_name_column_name) ? lc($proband_last_name_column_name) : '';
+    if (length($last_col) and exists $context->{record}->{$last_col}) {
+        $particulars{lastName} = trim($context->{record}->{$last_col} // '');
+    }
+
+    my $dob_col = length($proband_date_of_birth_column_name) ? lc($proband_date_of_birth_column_name) : '';
+    if (length($dob_col) and exists $context->{record}->{$dob_col}) {
+        $particulars{dateOfBirth} = _normalize_proband_date_of_birth($context->{record}->{$dob_col});
+    }
+
+    my $gender_col = length($proband_gender_column_name) ? lc($proband_gender_column_name) : '';
+    if (length($gender_col) and exists $context->{record}->{$gender_col}) {
+        $particulars{gender} = trim($context->{record}->{$gender_col} // '');
+    }
+
+    return \%particulars;
+}
+
+sub proband_particulars_complete {
+    my ($particulars) = @_;
+    return 0 unless $particulars;
+    return (
+        length($particulars->{firstName} // '')
+        and length($particulars->{lastName} // '')
+        and length($particulars->{dateOfBirth} // '')
+        and length($particulars->{gender} // '')
+    ) ? 1 : 0;
+}
+
+sub any_proband_particular_present {
+    my ($particulars) = @_;
+    return 0 unless $particulars;
+    return (
+        length($particulars->{firstName} // '')
+        or length($particulars->{lastName} // '')
+        or length($particulars->{dateOfBirth} // '')
+        or length($particulars->{gender} // '')
+    ) ? 1 : 0;
+}
+
+sub build_proband_particulars_update {
+    my ($proband,$particulars) = @_;
+    return undef unless $proband and any_proband_particular_present($particulars);
+
+    my $existing_first = trim($proband->{firstName} // '');
+    my $existing_last = trim($proband->{lastName} // '');
+    my $existing_dob = _normalize_proband_date_of_birth($proband->{dateOfBirth});
+    my $existing_gender = _proband_gender_sex($proband);
+    my $was_blinded = _proband_blinded($proband);
+
+    my $first = length($particulars->{firstName}) ? $particulars->{firstName} : $existing_first;
+    my $last = length($particulars->{lastName}) ? $particulars->{lastName} : $existing_last;
+    my $dob = length($particulars->{dateOfBirth}) ? $particulars->{dateOfBirth} : $existing_dob;
+    my $gender = length($particulars->{gender}) ? $particulars->{gender} : $existing_gender;
+    $gender = $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex::NOT_KNOWN unless length($gender);
+
+    my $changed = $was_blinded;
+    $changed = 1 if $first ne $existing_first;
+    $changed = 1 if $last ne $existing_last;
+    $changed = 1 if _proband_dob_date_only($dob) ne _proband_dob_date_only($existing_dob);
+    $changed = 1 if $gender ne $existing_gender;
+    return undef unless $changed;
+
+    return {
+        "id" => $proband->{id},
+        "version" => $proband->{version},
+        "categoryId" => $proband->{category}->{id},
+        "departmentId" => $proband->{department}->{id},
+        "person" => ($proband->{person} ? \1 : \0),
+        "blinded" => \0,
+        "alias" => $proband->{alias},
+        "firstName" => $first,
+        "lastName" => $last,
+        "dateOfBirth" => $dob,
+        "gender" => $gender,
+    };
+}
+
+sub _normalize_proband_date_of_birth {
+    my ($v) = @_;
+    $v = trim($v // '');
+    return '' unless length($v);
+    if ($v =~ /^(\d{4}-\d{2}-\d{2})(?:\s+\d{1,2}:\d{2}(?::\d{2})?)?/) {
+        return $1 . ' 00:00:00';
+    }
+    if ($v =~ m{^(\d{1,2})[./](\d{1,2})[./](\d{4})}) {
+        return sprintf('%04d-%02d-%02d 00:00:00',$3,$2,$1);
+    }
+    return $v;
+}
+
+sub _proband_dob_date_only {
+    my ($v) = @_;
+    $v = trim($v // '');
+    return $1 if $v =~ /^(\d{4}-\d{2}-\d{2})/;
+    return $v;
+}
+
+sub _proband_gender_sex {
+    my ($proband) = @_;
+    my $g = $proband->{gender};
+    return '' unless defined $g;
+    return trim($g) unless ref $g;
+    return trim($g->{sex} // '');
+}
+
+sub _proband_blinded {
+    my ($proband) = @_;
+    my $b = $proband->{blinded};
+    return 0 unless defined $b;
+    if (ref $b) {
+        return $$b ? 1 : 0 if ref $b eq 'SCALAR';
+        return $b ? 1 : 0;
+    }
+    return $b ? 1 : 0;
 }
 
 sub init_context {

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -409,6 +409,9 @@ sub build_proband_particulars_update {
     my $gender = length($particulars->{gender}) ? $particulars->{gender} : $existing_gender;
     $gender = $CTSMS::BulkProcessor::RestRequests::ctsms::shared::SelectionSetService::Sex::NOT_KNOWN unless length($gender);
 
+    # CTSMS rejects dateOfBirth "" (ParseException). Need a real DOB from sheet or existing record.
+    return undef unless length($dob);
+
     my $changed = $was_blinded;
     $changed = 1 if $first ne $existing_first;
     $changed = 1 if $last ne $existing_last;

--- a/CTSMS/BulkProcessor/Projects/ETL/Import.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Import.pm
@@ -442,8 +442,17 @@ sub _normalize_proband_date_of_birth {
     if ($v =~ /^(\d{4}-\d{2}-\d{2})(?:\s+\d{1,2}:\d{2}(?::\d{2})?)?/) {
         return $1 . ' 00:00:00';
     }
-    if ($v =~ m{^(\d{1,2})[./](\d{1,2})[./](\d{4})}) {
+    # Excel serial (Spreadsheet parses dates as day counts).
+    if (my $excel_date = valid_excel_to_date($v)) {
+        return $excel_date;
+    }
+    # Dot-separated: day.month.year
+    if ($v =~ m{^(\d{1,2})\.(\d{1,2})\.(\d{4})$}) {
         return sprintf('%04d-%02d-%02d 00:00:00',$3,$2,$1);
+    }
+    # Slash-separated: month/day/year (US); do not share the DMY dot rule.
+    if ($v =~ m{^(\d{1,2})/(\d{1,2})/(\d{4})$}) {
+        return sprintf('%04d-%02d-%02d 00:00:00',$3,$1,$2);
     }
     return $v;
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -159,8 +159,12 @@ sub init {
             input_path => $input_path,
         );
     };
-    if ($@) {
+    if (my $err = $@) {
         $result = 0;
+        # terminate()/scripterror croak inside the eval above; re-surface so the
+        # console still shows the failure (e.g. invalid --id / trial id).
+        chomp($err);
+        warn($err . "\n");
         eval {
             update_job($FAILED_JOB_STATUS);
         };

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -139,6 +139,8 @@ my $header_rownum :shared = 0;
 my $registration :shared;
 my $warning_count :shared = 0;
 my $value_count :shared = 0;
+# proband ids already cleared this import run (shared across sheets/threads)
+my %inquiry_cleared_probands :shared = ();
 
 my $comment_char = '#';
 
@@ -151,6 +153,8 @@ sub import_inquiry_data_horizontal {
         $warning_count = 0;
         lock $value_count;
         $value_count = 0;
+        lock %inquiry_cleared_probands;
+        %inquiry_cleared_probands = ();
     }
 
     my $static_context = {};
@@ -429,38 +433,64 @@ sub _clear_inquiries {
     my $proband_id = $context->{proband}->{id};
     my $trial_id = $context->{inquiry_trial}->{id};
 
-    $context->{clear_map} = {};
+    $context->{clear_map} //= {};
 
-    if (not $context->{proband_created}
-        and ($clear_categories or $clear_all_categories)
-        and not exists $context->{clear_map}->{$proband_id}) {
-        my $columns = [];
-        $columns = $context->{all_columns} if $clear_all_categories;
-        $columns = $context->{columns} if $clear_categories;
-        my $removed_value_count = 0;
+    return $result unless (not $context->{proband_created}
+        and ($clear_categories or $clear_all_categories));
 
-        $context->{clear_map}->{$proband_id} = {};
-        foreach my $column (@$columns) {
-            my $category_map = $context->{clear_map}->{$proband_id};
-
-            my $category = ($column->{inquiry}->{category} // '');
-            unless (exists $category_map->{$category}) {
-                my $values;
-                my $category_label = "inquiry category '" . $category . "'";
-                eval {
-                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
-                };
-                if ($@) {
-                    _warn_or_error($context,"error deleting $category_label values: " . $@);
-                    $result = 0;
-                } else {
-                    _info($context,"$category_label values deleted",1);
-                }
-                $category_map->{$category} = $values;
-                $removed_value_count += scalar @$values;
+    # clear_all_categories: wipe once per proband for the whole import (all sheets/threads).
+    if ($clear_all_categories) {
+        {
+            lock %inquiry_cleared_probands;
+            if (exists $inquiry_cleared_probands{$proband_id}
+                or exists $context->{clear_map}->{$proband_id}) {
+                return $result;
             }
+            $inquiry_cleared_probands{$proband_id} = 1;
+            $context->{clear_map}->{$proband_id} = 1;
         }
-        _info($context,"$removed_value_count inquiry values deleted");
+    } elsif (exists $context->{clear_map}->{$proband_id}) {
+        return $result;
+    } else {
+        $context->{clear_map}->{$proband_id} = {};
+    }
+
+    my $columns = [];
+    $columns = $context->{all_columns} if $clear_all_categories;
+    $columns = $context->{columns} if $clear_categories;
+    my $removed_value_count = 0;
+    my %category_done = ();
+
+    foreach my $column (@$columns) {
+        my $category = ($column->{inquiry}->{category} // '');
+        if ($clear_all_categories) {
+            next if exists $category_done{$category};
+        } else {
+            my $category_map = $context->{clear_map}->{$proband_id};
+            next if exists $category_map->{$category};
+            $category_map->{$category} = 1;
+        }
+
+        my $values;
+        my $category_label = "inquiry category '" . $category . "'";
+        eval {
+            $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
+        };
+        if ($@) {
+            _warn_or_error($context,"error deleting $category_label values: " . $@);
+            $result = 0;
+        } else {
+            _info($context,"$category_label values deleted",1);
+            $removed_value_count += scalar @{$values // []};
+        }
+        $category_done{$category} = 1 if $clear_all_categories;
+    }
+    _info($context,"$removed_value_count inquiry values deleted");
+
+    if ($clear_all_categories and not $result) {
+        lock %inquiry_cleared_probands;
+        delete $inquiry_cleared_probands{$proband_id};
+        delete $context->{clear_map}->{$proband_id};
     }
     return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -108,7 +108,6 @@ use CTSMS::BulkProcessor::Projects::ETL::Import qw(
     
     append_probandalias_criterion
     append_probandid_criterion
-    find_probands_by_particulars
     
     get_values_stats
     
@@ -538,35 +537,18 @@ sub _register_proband {
                         $context->{proband_created} = 1;
                     }
                 } elsif (proband_particulars_complete($particulars)) {
-                    my $matched;
                     eval {
-                        my $by_particulars = find_probands_by_particulars($context,$particulars);
-                        if ((scalar @{$by_particulars // []}) > 1) {
-                            die("more than one proband found for name/date of birth");
-                        } elsif ((scalar @{$by_particulars // []}) == 1) {
-                            $matched = $by_particulars->[0];
-                        }
+                         my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                         $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
                     };
                     if ($@) {
-                        _warn_or_error($context,"error loading unblinded proband: " . $@);
+                        _warn_or_error($context,"error creating unblinded proband: " . $@);
                         $result = 0;
-                    } elsif ($matched) {
-                        $context->{proband} = $matched;
-                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " found");
                     } else {
-                        eval {
-                             my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
-                                 $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
-                             $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
-                             $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
-                        };
-                        if ($@) {
-                            _warn_or_error($context,"error creating unblinded proband: " . $@);
-                            $result = 0;
-                        } else {
-                            _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
-                            $context->{proband_created} = 1;
-                        }
+                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
+                        $context->{proband_created} = 1;
                     }
                 } else {
                     _warn_or_error($context,"alias required to create proband");
@@ -612,35 +594,18 @@ sub _register_proband {
                 $inquiry_proband_date_of_birth_column_name,$inquiry_proband_gender_column_name);
             if (proband_particulars_complete($particulars)) {
                 lock $registration;
-                my $matched;
                 eval {
-                    my $by_particulars = find_probands_by_particulars($context,$particulars);
-                    if ((scalar @{$by_particulars // []}) > 1) {
-                        die("more than one proband found for name/date of birth");
-                    } elsif ((scalar @{$by_particulars // []}) == 1) {
-                        $matched = $by_particulars->[0];
-                    }
+                     my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                         $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                     $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                     $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
                 };
                 if ($@) {
-                    _warn_or_error($context,"error loading unblinded proband: " . $@);
+                    _warn_or_error($context,"error creating unblinded proband: " . $@);
                     $result = 0;
-                } elsif ($matched) {
-                    $context->{proband} = $matched;
-                    _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " found");
                 } else {
-                    eval {
-                         my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
-                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
-                         $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
-                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
-                    };
-                    if ($@) {
-                        _warn_or_error($context,"error creating unblinded proband: " . $@);
-                        $result = 0;
-                    } else {
-                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
-                        $context->{proband_created} = 1;
-                    }
+                    _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
+                    $context->{proband_created} = 1;
                 }
                 if ($context->{proband} and $context->{proband}->locked) {
                     _info($context,"proband is locked");

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -429,40 +429,39 @@ sub _clear_inquiries {
     my $proband_id = $context->{proband}->{id};
     my $trial_id = $context->{inquiry_trial}->{id};
 
-    $context->{clear_map} //= {};
+    $context->{clear_map} = {};
 
-    return $result unless (not $context->{proband_created}
-        and ($clear_categories or $clear_all_categories));
+    if (not $context->{proband_created}
+        and ($clear_categories or $clear_all_categories)
+        and not exists $context->{clear_map}->{$proband_id}) {
+        my $columns = [];
+        $columns = $context->{all_columns} if $clear_all_categories;
+        $columns = $context->{columns} if $clear_categories;
+        my $removed_value_count = 0;
 
-    # Persist per-proband category clears across rows/sheets; do not bail if the
-    # map entry already exists (later sheets may introduce new categories).
-    $context->{clear_map}->{$proband_id} //= {};
+        $context->{clear_map}->{$proband_id} = {};
+        foreach my $column (@$columns) {
+            my $category_map = $context->{clear_map}->{$proband_id};
 
-    my $columns = [];
-    $columns = $context->{all_columns} if $clear_all_categories;
-    $columns = $context->{columns} if $clear_categories;
-    my $removed_value_count = 0;
-    my $category_map = $context->{clear_map}->{$proband_id};
-
-    foreach my $column (@$columns) {
-        my $category = ($column->{inquiry}->{category} // '');
-        next if exists $category_map->{$category};
-
-        my $values;
-        my $category_label = "inquiry category '" . $category . "'";
-        eval {
-            $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
-        };
-        if ($@) {
-            _warn_or_error($context,"error deleting $category_label values: " . $@);
-            $result = 0;
-        } else {
-            _info($context,"$category_label values deleted",1);
-            $removed_value_count += scalar @{$values // []};
+            my $category = ($column->{inquiry}->{category} // '');
+            unless (exists $category_map->{$category}) {
+                my $values;
+                my $category_label = "inquiry category '" . $category . "'";
+                eval {
+                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
+                };
+                if ($@) {
+                    _warn_or_error($context,"error deleting $category_label values: " . $@);
+                    $result = 0;
+                } else {
+                    _info($context,"$category_label values deleted",1);
+                }
+                $category_map->{$category} = $values;
+                $removed_value_count += scalar @$values;
+            }
         }
-        $category_map->{$category} = $values;
+        _info($context,"$removed_value_count inquiry values deleted");
     }
-    _info($context,"$removed_value_count inquiry values deleted");
     return $result;
 
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -18,6 +18,9 @@ use CTSMS::BulkProcessor::Projects::ETL::InquirySettings qw(
     $inquiry_proband_alias_column_name
     $inquiry_proband_category_column_name
     $inquiry_proband_department_column_name
+    $inquiry_proband_first_name_column_name
+    $inquiry_proband_last_name_column_name
+    $inquiry_proband_date_of_birth_column_name
     $inquiry_proband_gender_column_name
 
     get_proband_columns
@@ -109,6 +112,10 @@ use CTSMS::BulkProcessor::Projects::ETL::Import qw(
     get_values_stats
     
     get_proband_in
+    read_proband_particulars
+    proband_particulars_complete
+    any_proband_particular_present
+    build_proband_particulars_update
     
     init_context
     get_log_label
@@ -507,12 +514,16 @@ sub _register_proband {
                 _warn_or_error($context,"error loading proband: " . $@);
                 $result = 0;
             } elsif ((scalar @$probands) == 0) {
+                my $particulars = read_proband_particulars($context,
+                    $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,
+                    $inquiry_proband_date_of_birth_column_name,$inquiry_proband_gender_column_name);
                 if (defined $id) {
                     _warn_or_error($context,"cannot find proband id " . $id);
                     $result = 0;
                 } elsif (defined $alias) {
                     eval {
-                         my $in = get_proband_in($context,$alias,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name);
+                         my $in = get_proband_in($context,$alias,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
                          $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);                        
                          $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
                     };
@@ -522,6 +533,20 @@ sub _register_proband {
                     } else {
                         _info($context,"proband " . $context->{proband}->alias . " created");
                         #$proband_created = 1;
+                        $context->{proband_created} = 1;
+                    }
+                } elsif (proband_particulars_complete($particulars)) {
+                    eval {
+                         my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                         $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                    };
+                    if ($@) {
+                        _warn_or_error($context,"error creating unblinded proband: " . $@);
+                        $result = 0;
+                    } else {
+                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
                         $context->{proband_created} = 1;
                     }
                 } else {
@@ -539,6 +564,22 @@ sub _register_proband {
                 } else {
                     _info($context,"proband " . $context->{proband}->alias . " found");
                 }
+
+                my $particulars = read_proband_particulars($context,
+                    $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,
+                    $inquiry_proband_date_of_birth_column_name,$inquiry_proband_gender_column_name);
+                my $update_in = build_proband_particulars_update($context->{proband},$particulars);
+                if ($update_in) {
+                    eval {
+                        $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::update_item($update_in);
+                    };
+                    if ($@) {
+                        _warn_or_error($context,"error updating proband particulars: " . $@);
+                        $result = 0;
+                    } else {
+                        _info($context,"proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " particulars updated");
+                    }
+                }
             }
 
             if ($context->{proband} and $context->{proband}->locked) {
@@ -547,8 +588,32 @@ sub _register_proband {
             }
 
         } else {
-            _warn_or_error($context,"no criterion to load proband");
-            $result = 0;
+            my $particulars = read_proband_particulars($context,
+                $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,
+                $inquiry_proband_date_of_birth_column_name,$inquiry_proband_gender_column_name);
+            if (proband_particulars_complete($particulars)) {
+                lock $registration;
+                eval {
+                     my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                         $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                     $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                     $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                };
+                if ($@) {
+                    _warn_or_error($context,"error creating unblinded proband: " . $@);
+                    $result = 0;
+                } else {
+                    _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
+                    $context->{proband_created} = 1;
+                }
+                if ($context->{proband} and $context->{proband}->locked) {
+                    _info($context,"proband is locked");
+                    return 0;
+                }
+            } else {
+                _warn_or_error($context,"no criterion to load proband");
+                $result = 0;
+            }
         }
     }
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -429,39 +429,40 @@ sub _clear_inquiries {
     my $proband_id = $context->{proband}->{id};
     my $trial_id = $context->{inquiry_trial}->{id};
 
-    $context->{clear_map} = {};
+    $context->{clear_map} //= {};
 
-    if (not $context->{proband_created}
-        and ($clear_categories or $clear_all_categories)
-        and not exists $context->{clear_map}->{$proband_id}) {
-        my $columns = [];
-        $columns = $context->{all_columns} if $clear_all_categories;
-        $columns = $context->{columns} if $clear_categories;
-        my $removed_value_count = 0;
+    return $result unless (not $context->{proband_created}
+        and ($clear_categories or $clear_all_categories));
 
-        $context->{clear_map}->{$proband_id} = {};
-        foreach my $column (@$columns) {
-            my $category_map = $context->{clear_map}->{$proband_id};
+    # Persist per-proband category clears across rows/sheets; do not bail if the
+    # map entry already exists (later sheets may introduce new categories).
+    $context->{clear_map}->{$proband_id} //= {};
 
-            my $category = ($column->{inquiry}->{category} // '');
-            unless (exists $category_map->{$category}) {
-                my $values;
-                my $category_label = "inquiry category '" . $category . "'";
-                eval {
-                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
-                };
-                if ($@) {
-                    _warn_or_error($context,"error deleting $category_label values: " . $@);
-                    $result = 0;
-                } else {
-                    _info($context,"$category_label values deleted",1);
-                }
-                $category_map->{$category} = $values;
-                $removed_value_count += scalar @$values;
-            }
+    my $columns = [];
+    $columns = $context->{all_columns} if $clear_all_categories;
+    $columns = $context->{columns} if $clear_categories;
+    my $removed_value_count = 0;
+    my $category_map = $context->{clear_map}->{$proband_id};
+
+    foreach my $column (@$columns) {
+        my $category = ($column->{inquiry}->{category} // '');
+        next if exists $category_map->{$category};
+
+        my $values;
+        my $category_label = "inquiry category '" . $category . "'";
+        eval {
+            $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
+        };
+        if ($@) {
+            _warn_or_error($context,"error deleting $category_label values: " . $@);
+            $result = 0;
+        } else {
+            _info($context,"$category_label values deleted",1);
+            $removed_value_count += scalar @{$values // []};
         }
-        _info($context,"$removed_value_count inquiry values deleted");
+        $category_map->{$category} = $values;
     }
+    _info($context,"$removed_value_count inquiry values deleted");
     return $result;
 
 }

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -139,8 +139,6 @@ my $header_rownum :shared = 0;
 my $registration :shared;
 my $warning_count :shared = 0;
 my $value_count :shared = 0;
-# proband ids already cleared this import run (shared across sheets/threads)
-my %inquiry_cleared_probands :shared = ();
 
 my $comment_char = '#';
 
@@ -153,8 +151,6 @@ sub import_inquiry_data_horizontal {
         $warning_count = 0;
         lock $value_count;
         $value_count = 0;
-        lock %inquiry_cleared_probands;
-        %inquiry_cleared_probands = ();
     }
 
     my $static_context = {};
@@ -433,64 +429,38 @@ sub _clear_inquiries {
     my $proband_id = $context->{proband}->{id};
     my $trial_id = $context->{inquiry_trial}->{id};
 
-    $context->{clear_map} //= {};
+    $context->{clear_map} = {};
 
-    return $result unless (not $context->{proband_created}
-        and ($clear_categories or $clear_all_categories));
+    if (not $context->{proband_created}
+        and ($clear_categories or $clear_all_categories)
+        and not exists $context->{clear_map}->{$proband_id}) {
+        my $columns = [];
+        $columns = $context->{all_columns} if $clear_all_categories;
+        $columns = $context->{columns} if $clear_categories;
+        my $removed_value_count = 0;
 
-    # clear_all_categories: wipe once per proband for the whole import (all sheets/threads).
-    if ($clear_all_categories) {
-        {
-            lock %inquiry_cleared_probands;
-            if (exists $inquiry_cleared_probands{$proband_id}
-                or exists $context->{clear_map}->{$proband_id}) {
-                return $result;
-            }
-            $inquiry_cleared_probands{$proband_id} = 1;
-            $context->{clear_map}->{$proband_id} = 1;
-        }
-    } elsif (exists $context->{clear_map}->{$proband_id}) {
-        return $result;
-    } else {
         $context->{clear_map}->{$proband_id} = {};
-    }
-
-    my $columns = [];
-    $columns = $context->{all_columns} if $clear_all_categories;
-    $columns = $context->{columns} if $clear_categories;
-    my $removed_value_count = 0;
-    my %category_done = ();
-
-    foreach my $column (@$columns) {
-        my $category = ($column->{inquiry}->{category} // '');
-        if ($clear_all_categories) {
-            next if exists $category_done{$category};
-        } else {
+        foreach my $column (@$columns) {
             my $category_map = $context->{clear_map}->{$proband_id};
-            next if exists $category_map->{$category};
-            $category_map->{$category} = 1;
-        }
 
-        my $values;
-        my $category_label = "inquiry category '" . $category . "'";
-        eval {
-            $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
-        };
-        if ($@) {
-            _warn_or_error($context,"error deleting $category_label values: " . $@);
-            $result = 0;
-        } else {
-            _info($context,"$category_label values deleted",1);
-            $removed_value_count += scalar @{$values // []};
+            my $category = ($column->{inquiry}->{category} // '');
+            unless (exists $category_map->{$category}) {
+                my $values;
+                my $category_label = "inquiry category '" . $category . "'";
+                eval {
+                    $values = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::InquiryValue::clear($proband_id, $trial_id, $category);
+                };
+                if ($@) {
+                    _warn_or_error($context,"error deleting $category_label values: " . $@);
+                    $result = 0;
+                } else {
+                    _info($context,"$category_label values deleted",1);
+                }
+                $category_map->{$category} = $values;
+                $removed_value_count += scalar @$values;
+            }
         }
-        $category_done{$category} = 1 if $clear_all_categories;
-    }
-    _info($context,"$removed_value_count inquiry values deleted");
-
-    if ($clear_all_categories and not $result) {
-        lock %inquiry_cleared_probands;
-        delete $inquiry_cleared_probands{$proband_id};
-        delete $context->{clear_map}->{$proband_id};
+        _info($context,"$removed_value_count inquiry values deleted");
     }
     return $result;
 

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImport.pm
@@ -108,6 +108,7 @@ use CTSMS::BulkProcessor::Projects::ETL::Import qw(
     
     append_probandalias_criterion
     append_probandid_criterion
+    find_probands_by_particulars
     
     get_values_stats
     
@@ -537,18 +538,35 @@ sub _register_proband {
                         $context->{proband_created} = 1;
                     }
                 } elsif (proband_particulars_complete($particulars)) {
+                    my $matched;
                     eval {
-                         my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
-                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
-                         $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
-                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                        my $by_particulars = find_probands_by_particulars($context,$particulars);
+                        if ((scalar @{$by_particulars // []}) > 1) {
+                            die("more than one proband found for name/date of birth");
+                        } elsif ((scalar @{$by_particulars // []}) == 1) {
+                            $matched = $by_particulars->[0];
+                        }
                     };
                     if ($@) {
-                        _warn_or_error($context,"error creating unblinded proband: " . $@);
+                        _warn_or_error($context,"error loading unblinded proband: " . $@);
                         $result = 0;
+                    } elsif ($matched) {
+                        $context->{proband} = $matched;
+                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " found");
                     } else {
-                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
-                        $context->{proband_created} = 1;
+                        eval {
+                             my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                                 $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                             $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                             $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                        };
+                        if ($@) {
+                            _warn_or_error($context,"error creating unblinded proband: " . $@);
+                            $result = 0;
+                        } else {
+                            _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
+                            $context->{proband_created} = 1;
+                        }
                     }
                 } else {
                     _warn_or_error($context,"alias required to create proband");
@@ -594,18 +612,35 @@ sub _register_proband {
                 $inquiry_proband_date_of_birth_column_name,$inquiry_proband_gender_column_name);
             if (proband_particulars_complete($particulars)) {
                 lock $registration;
+                my $matched;
                 eval {
-                     my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
-                         $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
-                     $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
-                     $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                    my $by_particulars = find_probands_by_particulars($context,$particulars);
+                    if ((scalar @{$by_particulars // []}) > 1) {
+                        die("more than one proband found for name/date of birth");
+                    } elsif ((scalar @{$by_particulars // []}) == 1) {
+                        $matched = $by_particulars->[0];
+                    }
                 };
                 if ($@) {
-                    _warn_or_error($context,"error creating unblinded proband: " . $@);
+                    _warn_or_error($context,"error loading unblinded proband: " . $@);
                     $result = 0;
+                } elsif ($matched) {
+                    $context->{proband} = $matched;
+                    _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " found");
                 } else {
-                    _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
-                    $context->{proband_created} = 1;
+                    eval {
+                         my $in = get_proband_in($context,undef,$inquiry_proband_category_column_name,$inquiry_proband_department_column_name,$inquiry_proband_gender_column_name,
+                             $inquiry_proband_first_name_column_name,$inquiry_proband_last_name_column_name,$inquiry_proband_date_of_birth_column_name);
+                         $in->{"person"} = ($context->{inquiry_trial}->{type}->{person} ? \1 : \0);
+                         $context->{proband} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::add_item($in);
+                    };
+                    if ($@) {
+                        _warn_or_error($context,"error creating unblinded proband: " . $@);
+                        $result = 0;
+                    } else {
+                        _info($context,"unblinded proband " . ($context->{proband}->alias // $context->{proband}->{id}) . " created");
+                        $context->{proband_created} = 1;
+                    }
                 }
                 if ($context->{proband} and $context->{proband}->locked) {
                     _info($context,"proband is locked");

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -136,8 +136,12 @@ sub init {
             input_path => $input_path,
         );
     };
-    if ($@) {
+    if (my $err = $@) {
         $result = 0;
+        # terminate()/scripterror croak inside the eval above; re-surface so the
+        # console still shows the failure (e.g. invalid --id / trial id).
+        chomp($err);
+        warn($err . "\n");
         eval {
             update_job($FAILED_JOB_STATUS);
         };

--- a/CTSMS/BulkProcessor/Projects/ETL/InquirySettings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquirySettings.pm
@@ -76,6 +76,9 @@ our @EXPORT_OK = qw(
     $inquiry_proband_alias_column_name
     $inquiry_proband_category_column_name
     $inquiry_proband_department_column_name
+    $inquiry_proband_first_name_column_name
+    $inquiry_proband_last_name_column_name
+    $inquiry_proband_date_of_birth_column_name
     $inquiry_proband_gender_column_name
 
     $ctsms_base_url
@@ -102,6 +105,9 @@ our $inquiry_data_api_values_page_size = 10;
 our $inquiry_proband_alias_column_name = 'alias';
 our $inquiry_proband_category_column_name;
 our $inquiry_proband_department_column_name;
+our $inquiry_proband_first_name_column_name;
+our $inquiry_proband_last_name_column_name;
+our $inquiry_proband_date_of_birth_column_name;
 our $inquiry_proband_gender_column_name;
 
 our $ctsms_base_url = undef;
@@ -234,6 +240,9 @@ sub update_settings {
         $inquiry_proband_alias_column_name = $data->{inquiry_proband_alias_column_name} if exists $data->{inquiry_proband_alias_column_name};
         $inquiry_proband_category_column_name = $data->{inquiry_proband_category_column_name} if exists $data->{inquiry_proband_category_column_name};
         $inquiry_proband_department_column_name = $data->{inquiry_proband_department_column_name} if exists $data->{inquiry_proband_department_column_name};
+        $inquiry_proband_first_name_column_name = $data->{inquiry_proband_first_name_column_name} if exists $data->{inquiry_proband_first_name_column_name};
+        $inquiry_proband_last_name_column_name = $data->{inquiry_proband_last_name_column_name} if exists $data->{inquiry_proband_last_name_column_name};
+        $inquiry_proband_date_of_birth_column_name = $data->{inquiry_proband_date_of_birth_column_name} if exists $data->{inquiry_proband_date_of_birth_column_name};
         $inquiry_proband_gender_column_name = $data->{inquiry_proband_gender_column_name} if exists $data->{inquiry_proband_gender_column_name};
 
         $inquiry_data_api_probands_page_size = $data->{inquiry_data_api_probands_page_size} if exists $data->{inquiry_data_api_probands_page_size};
@@ -279,11 +288,17 @@ sub get_proband_columns {
         push(@columns,$proband->{alias}) if length($inquiry_proband_alias_column_name);
         push(@columns,$proband->{category}->{nameL10nKey}) if length($inquiry_proband_category_column_name);
         push(@columns,$proband->{department}->{nameL10nKey}) if length($inquiry_proband_department_column_name);
+        push(@columns,$proband->{firstName}) if length($inquiry_proband_first_name_column_name);
+        push(@columns,$proband->{lastName}) if length($inquiry_proband_last_name_column_name);
+        push(@columns,$proband->{dateOfBirth}) if length($inquiry_proband_date_of_birth_column_name);
         push(@columns,$proband->{gender}->{sex}) if length($inquiry_proband_gender_column_name);
     } else {
         push(@columns,lc($inquiry_proband_alias_column_name)) if length($inquiry_proband_alias_column_name);
         push(@columns,lc($inquiry_proband_category_column_name)) if length($inquiry_proband_category_column_name);
         push(@columns,lc($inquiry_proband_department_column_name)) if length($inquiry_proband_department_column_name);
+        push(@columns,lc($inquiry_proband_first_name_column_name)) if length($inquiry_proband_first_name_column_name);
+        push(@columns,lc($inquiry_proband_last_name_column_name)) if length($inquiry_proband_last_name_column_name);
+        push(@columns,lc($inquiry_proband_date_of_birth_column_name)) if length($inquiry_proband_date_of_birth_column_name);
         push(@columns,lc($inquiry_proband_gender_column_name)) if length($inquiry_proband_gender_column_name);
     }
     return @columns;


### PR DESCRIPTION
## Summary
- Extend eCRF/Inquiry import to create unblinded Probands when first_name, last_name, date_of_birth, and gender are all present
- Merge-update existing Probands when any of those identity columns is non-empty (keep old values for empty cells)
- Wire empty-by-default settings so exporters omit identity columns unless configured

## Test plan
- [ ] Import with all four identity columns set creates an unblinded Proband
- [ ] Import missing any identity column keeps blinded create behavior
- [ ] Found Proband with partial identity columns merges/updates without clearing other particulars
- [ ] Default export settings still omit first_name/last_name/date_of_birth/gender


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imports can use configured proband first name, last name, date of birth, and gender fields.
  * Existing proband records can be enriched or updated from imported particulars.
  * Complete imported particulars can create unblinded proband records.
  * REST API connectors can automatically reuse a matching available JWT.

* **Bug Fixes**
  * Import and export initialization errors now display clearer messages.
  * Corrected generated logging configuration for standard error output.
  * Improved logging when multithreaded processing lacks a thread identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->