### PR TITLE
Re-issue --auth JWTs with long validity at ETL startup

### DIFF
--- a/CTSMS/BulkProcessor/Globals.pm
+++ b/CTSMS/BulkProcessor/Globals.pm
@@ -66,6 +66,7 @@ our @EXPORT_OK = qw(
     $ctsmsrestapi_password
     $ctsmsrestapi_realm
     $ctsmsrestapi_path
+    $ctsmsrestapi_jwt_validity_secs
 
 	$csv_path
 
@@ -171,6 +172,8 @@ our $ctsmsrestapi_username = 'user_9qxs_1_1';
 our $ctsmsrestapi_password = 'user_9qxs_1_1';
 our $ctsmsrestapi_realm = 'api';
 our $ctsmsrestapi_path = 'rest';
+# JWT lifetime requested when ETL jobs re-issue --auth tokens at startup (24h).
+our $ctsmsrestapi_jwt_validity_secs = 24 * 60 * 60;
 
 our $working_path = tempdir(CLEANUP => 0) . '/'; #'/var/xy/';
 
@@ -284,6 +287,7 @@ sub update_masterconfig {
         $ctsmsrestapi_username = $data->{ctsmsrestapi_username} if exists $data->{ctsmsrestapi_username};
         $ctsmsrestapi_password = $data->{ctsmsrestapi_password} if exists $data->{ctsmsrestapi_password};
         $ctsmsrestapi_realm = $data->{ctsmsrestapi_realm} if exists $data->{ctsmsrestapi_realm};
+        $ctsmsrestapi_jwt_validity_secs = $data->{ctsmsrestapi_jwt_validity_secs} if exists $data->{ctsmsrestapi_jwt_validity_secs};
 
         $cpucount = $data->{cpucount} if exists $data->{cpucount};
         $enablemultithreading = $data->{enablemultithreading} if exists $data->{enablemultithreading};

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/process.pl
@@ -11,6 +11,7 @@ use Getopt::Long qw(GetOptions);
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
+    $ctsmsrestapi_jwt_validity_secs
 );
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
@@ -187,6 +188,7 @@ sub init {
             $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
+            $api->extend_jwt_validity($ctsmsrestapi_jwt_validity_secs);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfImporter/process.pl
@@ -11,6 +11,7 @@ use Getopt::Long qw(GetOptions);
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
+    $ctsmsrestapi_jwt_validity_secs
 );
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
@@ -135,6 +136,7 @@ sub init {
             $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
+            $api->extend_jwt_validity($ctsmsrestapi_jwt_validity_secs);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfSettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::EcrfImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExporter/process.pl
@@ -11,6 +11,7 @@ use Getopt::Long qw(GetOptions);
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
+    $ctsmsrestapi_jwt_validity_secs
 );
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
@@ -152,6 +153,7 @@ sub init {
             $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
+            $api->extend_jwt_validity($ctsmsrestapi_jwt_validity_secs);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryExporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryImporter/process.pl
@@ -11,6 +11,7 @@ use Getopt::Long qw(GetOptions);
 use CTSMS::BulkProcessor::Globals qw(
     $ctsmsrestapi_username
     $ctsmsrestapi_password
+    $ctsmsrestapi_jwt_validity_secs
 );
 use CTSMS::BulkProcessor::ConnectorPool qw(
     get_ctsms_restapi
@@ -129,6 +130,7 @@ sub init {
             $ctsmsrestapi_username = get_username_from_jwt($auth);
             my $api = get_ctsms_restapi();
             $api->jwt($auth);
+            $api->extend_jwt_validity($ctsmsrestapi_jwt_validity_secs);
         }
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquirySettings::update_settings,$YAML_CONFIG_TYPE);
         $result &= load_config($settingsfile,\&CTSMS::BulkProcessor::Projects::ETL::InquiryImporter::Settings::update_settings,$YAML_CONFIG_TYPE);

--- a/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
+++ b/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
@@ -175,15 +175,36 @@ sub _renew_jwt_if_required {
 sub _force_renew_jwt {
 
     my $self = shift;
+    my ($validity_secs) = @_;
     return 0 unless defined $self->{jwt} && length($self->{jwt}) > 0;
     undef $self->{jwt_refresh_cooldown_until};
-    return $self->_renew_jwt();
+    return $self->_renew_jwt($validity_secs);
+
+}
+
+# Re-issue the current Bearer JWT with an explicit lifetime (used by ETL --auth startup).
+# Croaks on failure so jobs do not continue with a short-lived token.
+sub extend_jwt_validity {
+
+    my $self = shift;
+    my ($validity_secs) = @_;
+    unless (defined $self->{jwt} && length($self->{jwt}) > 0) {
+        resterror($self, 'rest api jwt extend requires a jwt', getlogger(__PACKAGE__));
+    }
+    my $renewed = $self->_force_renew_jwt($validity_secs);
+    unless ($renewed) {
+        resterror($self, 'rest api jwt extend failed', getlogger(__PACKAGE__));
+    }
+    restinfo($self, 'rest api jwt validity extended to ' . ($self->{jwt_validity_secs} // '?') . 's', getlogger(__PACKAGE__));
+    return 1;
 
 }
 
 sub _renew_jwt {
 
     my $self = shift;
+    my ($validity_secs) = @_;
+    $validity_secs = $self->{jwt_validity_secs} unless defined $validity_secs;
     my $skew = $self->jwt_refresh_skew_secs();
     my $renewed = 0;
     $self->{_refreshing_jwt} = 1;
@@ -191,7 +212,7 @@ sub _renew_jwt {
         # Runtime require avoids a circular use with Login.pm (which uses CtsmsRestApi).
         require CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login;
         my $new_jwt = CTSMS::BulkProcessor::RestRequests::ctsms::shared::ToolsService::Login::issue_jwt(
-            $self->{jwt_validity_secs},
+            $validity_secs,
             $self,
         );
         if (defined $new_jwt && !ref $new_jwt && length($new_jwt) > 0) {


### PR DESCRIPTION
## Summary
- ETL jobs started with `--auth` immediately re-issue the JWT via `extend_jwt_validity` so connectors can idle without relying on short-lived Bearer refresh.
- Adds configurable `ctsmsrestapi_jwt_validity_secs` (default 24h); omitting validity_secs is not used because the server falls back to SESSION_TIMEOUT_TRUSTED (180s).
- Wired into eCRF/inquiry importer and exporter `process.pl` init paths before workers inherit the token.

## Test plan
- [ ] Run an ETL job with `--auth` and confirm logs show JWT refreshed/extended (~86400s).
- [ ] Leave the job idle past the original short JWT expiry; subsequent REST calls still succeed.
- [ ] Confirm an already-expired `--auth` JWT fails immediately at startup.
- [ ] Optionally override `ctsmsrestapi_jwt_validity_secs` in config and verify the new lifetime is requested.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable JWT session validity, with a default duration of 24 hours.
  - Added support for extending authentication validity during export and import operations.

- **Improvements**
  - Authenticated ETL workflows now apply the configured token lifetime consistently.
  - Improved handling and reporting when token renewal cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->