### PR TITLE
Add option to skip eCRFs with undef status

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
@@ -25,6 +25,7 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
 
     $ecrf_data_api_ecrffields_page_size
     $ecrf_data_api_probandlistentrytagvalues_page_size
+    $ecrf_data_include_undef_ecrf_status
 
     %colname_abbreviation
     ecrf_data_include_ecrffield
@@ -490,11 +491,12 @@ NEXT_VISIT:
                 $context->{api_values_page_total_count} = undef;
                 $context->{api_values_page_num} = 0; #roll over
                 $context->{ecrf_status} = eval { CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfStatusEntry::get_item($context->{listentry}->{id},$context->{ecrf}->{id},$context->{visit}->{id}) };
-                if (not $context->{signed} or ($context->{ecrf_status} and $context->{ecrf_status}->{status}->{done})) {
+                if ($context->{signed} ? ($context->{ecrf_status} and $context->{ecrf_status}->{status}->{done})
+                        : ($ecrf_data_include_undef_ecrf_status or $context->{ecrf_status})) {
                     _info($context,'proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
                           (defined $context->{visit}->{id} ? '@' . $context->{visit}->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'));                    
                 } else {
-                    _info($context,'skipping unsigned - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
+                    _info($context,($context->{signed} ? 'skipping unsigned' : 'skipping <new>') . ' - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
                           (defined $context->{visit}->{id} ? '@' . $context->{visit}->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'),1);                    
                     $context->{ecrf} = undef;
                     $context->{ecrf_status} = undef;
@@ -918,7 +920,8 @@ sub _get_ecrffieldvalues {
                 $context->{visit} = undef;
             }
             $context->{ecrf_status} = eval { CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfStatusEntry::get_item($context->{listentry}->{id},$ecrfid,$visit->{id}) };
-            if (not $context->{signed} or ($context->{ecrf_status} and $context->{ecrf_status}->{status}->{done})) {
+            if ($context->{signed} ? ($context->{ecrf_status} and $context->{ecrf_status}->{status}->{done})
+                    : ($ecrf_data_include_undef_ecrf_status or $context->{ecrf_status})) {
                 $context->{ecrf_count} += 1;
                 _info($context,'proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
                       (defined $visit->{id} ? '@' . $visit->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'));
@@ -945,7 +948,7 @@ sub _get_ecrffieldvalues {
                     }
                 }
             } else {
-                _info($context,'skipping unsigned - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
+                _info($context,($context->{signed} ? 'skipping unsigned' : 'skipping <new>') . ' - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
                       (defined $visit->{id} ? '@' . $visit->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'),1);
             }
         }

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
@@ -498,9 +498,9 @@ NEXT_VISIT:
                 } else {
                     _info($context,($context->{signed} ? 'skipping unsigned' : 'skipping <new>') . ' - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
                           (defined $context->{visit}->{id} ? '@' . $context->{visit}->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'),1);                    
-                    $context->{ecrf} = undef;
+                    $context->{visit} = undef;
                     $context->{ecrf_status} = undef;
-                    goto NEXT_ECRF;
+                    goto NEXT_VISIT;
                 }
             } else {
                 $context->{ecrf} = undef;

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfSettings.pm
@@ -38,7 +38,7 @@ use CTSMS::BulkProcessor::ConnectorPool qw(
 
 );
 
-use CTSMS::BulkProcessor::Utils qw(format_number prompt chopstring );
+use CTSMS::BulkProcessor::Utils qw(format_number prompt chopstring stringtobool);
 
 use CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::Trial qw();
 
@@ -67,6 +67,7 @@ our @EXPORT_OK = qw(
     $ecrf_data_api_probandlistentrytagvalues_page_size
     $ecrf_data_api_probandlistentrytags_page_size
     $ecrf_data_api_ecrffields_page_size
+    $ecrf_data_include_undef_ecrf_status
 
     %colname_abbreviation
     $col_per_selection_set_value
@@ -111,6 +112,7 @@ our $ecrf_data_api_values_page_size = 10;
 our $ecrf_data_api_probandlistentrytagvalues_page_size = 10;
 our $ecrf_data_api_probandlistentrytags_page_size = 10;
 our $ecrf_data_api_ecrffields_page_size = 100;
+our $ecrf_data_include_undef_ecrf_status = 1;
 
 our $ctsms_base_url = undef;
 our $dbtool = undef;
@@ -291,6 +293,7 @@ sub update_settings {
         $ecrf_data_api_probandlistentrytagvalues_page_size = $data->{ecrf_data_api_probandlistentrytagvalues_page_size} if exists $data->{ecrf_data_api_probandlistentrytagvalues_page_size};
         $ecrf_data_api_probandlistentrytags_page_size = $data->{ecrf_data_api_probandlistentrytags_page_size} if exists $data->{ecrf_data_api_probandlistentrytags_page_size};
         $ecrf_data_api_ecrffields_page_size = $data->{ecrf_data_api_ecrffields_page_size} if exists $data->{ecrf_data_api_ecrffields_page_size};
+        $ecrf_data_include_undef_ecrf_status = stringtobool($data->{ecrf_data_include_undef_ecrf_status}) if exists $data->{ecrf_data_include_undef_ecrf_status};
 
         $col_per_selection_set_value = $data->{col_per_selection_set_value} if exists $data->{col_per_selection_set_value};
         $selection_set_value_separator = $data->{selection_set_value_separator} if exists $data->{selection_set_value_separator};


### PR DESCRIPTION
## Summary
- Add YAML setting `ecrf_data_include_undef_ecrf_status` (default `1`) in EcrfSettings
- Vertical and horizontal eCRF export skip `<new>`/undef status eCRFs when the option is `0`
- Existing `--signed` (done-only) behavior is unchanged

## Test plan
- [ ] Run eCRF export with `ecrf_data_include_undef_ecrf_status: 1` — `<new>` eCRFs still included
- [ ] Run with `ecrf_data_include_undef_ecrf_status: 0` — logs show `skipping <new>` and those eCRFs are omitted
- [ ] Run with `--signed` — still only exports done statuses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ECRF exports can now include records without a status during unsigned-mode processing.
  * This behavior is enabled by default and can be configured.
* **Bug Fixes**
  * Signed-mode exports continue to require completed ECRF status.
  * Export messages now clearly distinguish unsigned ECRFs from newly created ECRFs that were skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->