### PR TITLE
Speed up eCRF and inquiry export pagination and field-value fetch

### DIFF
--- a/CTSMS/BulkProcessor/Projects/ETL/Ecrf.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Ecrf.pm
@@ -185,13 +185,13 @@ sub _get_ecrffields {
     my @ecrffields;
     while (1) {
         if ((scalar @$api_ecrffields_page) == 0) {
-            my $p = { page_size => $ecrf_data_api_ecrffields_page_size , page_num => $api_ecrffields_page_num + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_ecrffields_page_size , page_num => $api_ecrffields_page_num + 1, total_count => undef, total_count_expected => not defined $api_ecrffields_page_total_count };
             my $sf = {};
 
             my $first = $api_ecrffields_page_num * $ecrf_data_api_ecrffields_page_size;
             _info($context,"fetch eCRF fields page: " . $first . '-' . ($first + $ecrf_data_api_ecrffields_page_size) . ' of ' . (defined $api_ecrffields_page_total_count ? $api_ecrffields_page_total_count : '?'),not $show_page_progress);
             $api_ecrffields_page = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfField::get_trial_list($context->{ecrf_data_trial}->{id}, undef,1, $p, $sf, { _selectionSetValueMap => 1 });
-            $api_ecrffields_page_total_count = $p->{total_count};
+            $api_ecrffields_page_total_count = $p->{total_count} if defined $p->{total_count};
             $api_ecrffields_page_num += 1;
         }
         my $ecrffield = shift @$api_ecrffields_page;
@@ -209,13 +209,13 @@ sub _get_probandlistentrytags {
     my @listentrytags;
     while (1) {
         if ((scalar @$api_listentrytags_page) == 0) {
-            my $p = { page_size => $ecrf_data_api_probandlistentrytags_page_size , page_num => $api_listentrytags_page_num + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_probandlistentrytags_page_size , page_num => $api_listentrytags_page_num + 1, total_count => undef, total_count_expected => not defined $api_listentrytags_page_total_count };
             my $sf = { sort_by => 'position', sort_dir => 'asc', };
 
             my $first = $api_listentrytags_page_num * $ecrf_data_api_probandlistentrytags_page_size;
             _info($context,"fetch proband list attribute page: " . $first . '-' . ($first + $ecrf_data_api_probandlistentrytags_page_size) . ' of ' . (defined $api_listentrytags_page_total_count ? $api_listentrytags_page_total_count : '?'),not $show_page_progress);
             $api_listentrytags_page = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::ProbandListEntryTag::get_trial_list($context->{ecrf_data_trial}->{id}, undef, $p, $sf, { _selectionSetValueMap => 1 });
-            $api_listentrytags_page_total_count = $p->{total_count};
+            $api_listentrytags_page_total_count = $p->{total_count} if defined $p->{total_count};
             $api_listentrytags_page_num += 1;
         }
         my $listentrytag = shift @$api_listentrytags_page;

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
@@ -461,14 +461,14 @@ sub _init_ecrf_data_vertical_context {
 
 NEXT_LISTENTRY:
         if (not defined $context->{api_listentries_page_total_count} or ($context->{api_listentries_page_num} * $ecrf_data_api_listentries_page_size < $context->{api_listentries_page_total_count} and (scalar @{$context->{api_listentries_page}}) == 0)) {
-            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_listentries_page_total_count} };
             my $sf = { sort_by => 'position', sort_dir => 'asc',
                        'proband.deferredDelete' => booltostring(0), };
 
             my $first = $context->{api_listentries_page_num} * $ecrf_data_api_listentries_page_size;
             _info($context,"fetch proband list entries page: " . $first . '-' . ($first + $ecrf_data_api_listentries_page_size) . ' of ' . (defined $context->{api_listentries_page_total_count} ? $context->{api_listentries_page_total_count} : '?'),not $show_page_progress);
             $context->{api_listentries_page} = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::ProbandListEntry::get_trial_list($context->{ecrf_data_trial}->{id}, undef, undef, 1, $p, $sf);
-            $context->{api_listentries_page_total_count} = $p->{total_count};
+            $context->{api_listentries_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_listentries_page_num} += 1;
         }
         if (not defined $context->{listentry}) {
@@ -485,13 +485,13 @@ NEXT_LISTENTRY:
 
 NEXT_ECRF:
         if (not defined $context->{api_ecrfs_page_total_count} or ($context->{api_ecrfs_page_num} * $ecrf_data_api_ecrfs_page_size < $context->{api_ecrfs_page_total_count} and (scalar @{$context->{api_ecrfs_page}}) == 0)) {
-            my $p = { page_size => $ecrf_data_api_ecrfs_page_size , page_num => $context->{api_ecrfs_page_num} + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_ecrfs_page_size , page_num => $context->{api_ecrfs_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_ecrfs_page_total_count} };
             my $sf = {};
 
             my $first = $context->{api_ecrfs_page_num} * $ecrf_data_api_ecrfs_page_size;
             _info($context,"fetch eCRFs page: " . $first . '-' . ($first + $ecrf_data_api_ecrfs_page_size) . ' of ' . (defined $context->{api_ecrfs_page_total_count} ? $context->{api_ecrfs_page_total_count} : '?'),not $show_page_progress);
             $context->{api_ecrfs_page} = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::Ecrf::get_trial_list($context->{ecrf_data_trial}->{id}, 1, $p, $sf);
-            $context->{api_ecrfs_page_total_count} = $p->{total_count};
+            $context->{api_ecrfs_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_ecrfs_page_num} += 1;
         }
         if (not defined $context->{ecrf}) {
@@ -537,7 +537,7 @@ NEXT_VISIT:
 
 NEXT_VALUE:
         if (not defined $context->{api_values_page_total_count} or ($context->{api_values_page_num} * $ecrf_data_api_values_page_size < $context->{api_values_page_total_count} and (scalar @{$context->{api_values_page}}) == 0)) {
-            my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $context->{api_values_page_num} + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $context->{api_values_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_values_page_total_count} };
             my $sf = {}; #sorted by default
 
             my $first = $context->{api_values_page_num} * $ecrf_data_api_values_page_size;
@@ -548,7 +548,7 @@ NEXT_VALUE:
             if ($@) {
                 $context->{api_values_page} = [];
             }
-            $context->{api_values_page_total_count} = $p->{total_count};
+            $context->{api_values_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_values_page_num} += 1;
         }
         my $value = shift @{$context->{api_values_page}};
@@ -737,14 +737,14 @@ sub _init_ecrf_data_pdfs_context {
         my ($context) = @_;
 
         if ((scalar @{$context->{api_listentries_page}}) == 0) {
-            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_listentries_page_total_count} };
             my $sf = { sort_by => 'position', sort_dir => 'asc',
                        'proband.deferredDelete' => booltostring(0), };
 
             my $first = $context->{api_listentries_page_num} * $ecrf_data_api_listentries_page_size;
             _info($context,"fetch proband list entries page: " . $first . '-' . ($first + $ecrf_data_api_listentries_page_size) . ' of ' . (defined $context->{api_listentries_page_total_count} ? $context->{api_listentries_page_total_count} : '?'),not $show_page_progress);
             $context->{api_listentries_page} = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::ProbandListEntry::get_trial_list($context->{ecrf_data_trial}->{id}, undef, undef, 1, $p, $sf);
-            $context->{api_listentries_page_total_count} = $p->{total_count};
+            $context->{api_listentries_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_listentries_page_num} += 1;
         }
         $context->{listentry} = shift @{$context->{api_listentries_page}};
@@ -785,14 +785,14 @@ sub _init_ecrf_data_horizontal_context {
         my ($context) = @_;
 
         if ((scalar @{$context->{api_listentries_page}}) == 0) {
-            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_listentries_page_size , page_num => $context->{api_listentries_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_listentries_page_total_count} };
             my $sf = { sort_by => 'position', sort_dir => 'asc',
                        'proband.deferredDelete' => booltostring(0), };
 
             my $first = $context->{api_listentries_page_num} * $ecrf_data_api_listentries_page_size;
             _info($context,"fetch proband list entries page: " . $first . '-' . ($first + $ecrf_data_api_listentries_page_size) . ' of ' . (defined $context->{api_listentries_page_total_count} ? $context->{api_listentries_page_total_count} : '?'),not $show_page_progress);
             $context->{api_listentries_page} = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::ProbandListEntry::get_trial_list($context->{ecrf_data_trial}->{id}, undef, undef, 1, $p, $sf);
-            $context->{api_listentries_page_total_count} = $p->{total_count};
+            $context->{api_listentries_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_listentries_page_num} += 1;
         }
         $context->{listentry} = shift @{$context->{api_listentries_page}};
@@ -907,7 +907,7 @@ sub _get_probandlistentrytagvalues {
     my @listentrytagvalues;
     while (1) {
         if ((scalar @$api_listentrytagvalues_page) == 0) {
-            my $p = { page_size => $ecrf_data_api_probandlistentrytagvalues_page_size , page_num => $api_listentrytagvalues_page_num + 1, total_count => undef };
+            my $p = { page_size => $ecrf_data_api_probandlistentrytagvalues_page_size , page_num => $api_listentrytagvalues_page_num + 1, total_count => undef, total_count_expected => not defined $api_listentrytagvalues_page_total_count };
             my $sf = {}; #sorted by default
 
             my $first = $api_listentrytagvalues_page_num * $ecrf_data_api_probandlistentrytagvalues_page_size;
@@ -918,7 +918,7 @@ sub _get_probandlistentrytagvalues {
             #if ($@) {
             #    $api_listentrytagvalues_page = [];
             #}
-            $api_listentrytagvalues_page_total_count = $p->{total_count};
+            $api_listentrytagvalues_page_total_count = $p->{total_count} if defined $p->{total_count};
             $api_listentrytagvalues_page_num += 1;
         }
         my $listentrytagvalue = shift @$api_listentrytagvalues_page;
@@ -953,7 +953,7 @@ sub _get_ecrffieldvalues {
                       (defined $visit->{id} ? '@' . $visit->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'));
                 while (1) {
                     if ((scalar @$api_values_page) == 0) {
-                        my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef };
+                        my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef, total_count_expected => not defined $api_values_page_total_count };
                         my $sf = {}; #sorted by default
 
                         my $first = $api_values_page_num * $ecrf_data_api_values_page_size;
@@ -964,7 +964,7 @@ sub _get_ecrffieldvalues {
                         if ($@) {
                             $api_values_page = [];
                         }
-                        $api_values_page_total_count = $p->{total_count};
+                        $api_values_page_total_count = $p->{total_count} if defined $p->{total_count};
                         $api_values_page_num += 1;
                     }
                     my $value = shift @$api_values_page;

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
@@ -12,6 +12,9 @@ use CTSMS::BulkProcessor::Globals qw(
 
     $ctsmsrestapi_username
     $ctsmsrestapi_password
+
+    $enablemultithreading
+    $cpucount
 );
 
 use CTSMS::BulkProcessor::Projects::ETL::EcrfSettings qw(
@@ -66,7 +69,10 @@ use CTSMS::BulkProcessor::Projects::ETL::EcrfExporter::Settings qw(
 
     $proband_list_filename
     $ecrf_data_row_block
-    
+
+    $export_ecrf_fieldvalues_multithreading
+    $export_ecrf_fieldvalues_numofthreads
+
     $publish_public_file
 );
 
@@ -89,6 +95,8 @@ use CTSMS::BulkProcessor::LogError qw(
 );
 
 use File::Basename qw();
+
+use threads qw();
 
 use CTSMS::BulkProcessor::SqlConnectors::SQLiteDB qw();
 use CTSMS::BulkProcessor::SqlConnectors::CSVDB qw();
@@ -128,7 +136,7 @@ use CTSMS::BulkProcessor::Projects::ETL::ExcelExport qw();
 
 use CTSMS::BulkProcessor::Array qw(array_to_map);
 
-use CTSMS::BulkProcessor::Utils qw(booltostring timestampdigits run shell_args zerofill);
+use CTSMS::BulkProcessor::Utils qw(booltostring timestampdigits run shell_args zerofill threadid);
 
 require Exporter;
 our @ISA = qw(Exporter);
@@ -930,56 +938,143 @@ sub _get_probandlistentrytagvalues {
 
 sub _get_ecrffieldvalues {
     my ($context) = @_;
-    my @values;
-    $context->{ecrf_count} = 0;
+    my @jobs;
     foreach my $ecrfid (keys %{$context->{ecrf_map}}) {
-        $context->{ecrf} = $context->{ecrf_map}->{$ecrfid}->{ecrf};
-        my @visits = @{$context->{ecrf}->{visits} // []};
+        my $ecrf = $context->{ecrf_map}->{$ecrfid}->{ecrf};
+        my @visits = @{$ecrf->{visits} // []};
         push(@visits,{ id => undef, }) unless scalar @visits;
         foreach my $visit (@visits) {
-            my $api_values_page = [];
-            my $api_values_page_num = 0;
-            my $api_values_page_total_count;
-            if ($visit->{id}) {
-                $context->{visit} = $visit;
-            } else {
-                $context->{visit} = undef;
-            }
-            $context->{ecrf_status} = eval { CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfStatusEntry::get_item($context->{listentry}->{id},$ecrfid,$visit->{id}) };
-            if ($context->{signed} ? ($context->{ecrf_status} and $context->{ecrf_status}->{status}->{done})
-                    : ($ecrf_data_include_undef_ecrf_status or $context->{ecrf_status})) {
-                $context->{ecrf_count} += 1;
-                _info($context,'proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
-                      (defined $visit->{id} ? '@' . $visit->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'));
-                while (1) {
-                    if ((scalar @$api_values_page) == 0) {
-                        my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef, total_count_expected => not defined $api_values_page_total_count };
-                        my $sf = {}; #sorted by default
-
-                        my $first = $api_values_page_num * $ecrf_data_api_values_page_size;
-                        _info($context,"fetch eCRF values page: " . $first . '-' . ($first + $ecrf_data_api_values_page_size) . ' of ' . (defined $api_values_page_total_count ? $api_values_page_total_count : '?'),not $show_page_progress);
-                        eval {
-                            $api_values_page = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValues::get_ecrffieldvalues($context->{listentry}->{id},$ecrfid,$visit->{id},0, $timezone, $p, $sf, { _value => 1, _selectionValueMap => 1 })->{rows};
-                        };
-                        if ($@) {
-                            $api_values_page = [];
-                        }
-                        $api_values_page_total_count = $p->{total_count} if defined $p->{total_count};
-                        $api_values_page_num += 1;
-                    }
-                    my $value = shift @$api_values_page;
-                    last unless $value;
-                    if (not defined $value->{index} or defined $value->{id}) {
-                        push(@values,$value);
-                    }
-                }
-            } else {
-                _info($context,($context->{signed} ? 'skipping unsigned' : 'skipping <new>') . ' - proband ' . $context->{listentry}->{proband}->alias() . ": eCRF '$context->{ecrf}->{name}" .
-                      (defined $visit->{id} ? '@' . $visit->{token} : '') . "': " . ($context->{ecrf_status} ? $context->{ecrf_status}->{status}->{name} : '<new>'),1);
-            }
+            push(@jobs,{
+                listentry_id => $context->{listentry}->{id},
+                alias => $context->{listentry}->{proband}->alias(),
+                ecrfid => $ecrfid,
+                ecrf_name => $ecrf->{name},
+                visit_id => $visit->{id},
+                visit_token => $visit->{token},
+                signed => $context->{signed},
+            });
         }
     }
+
+    my $use_threads = ($enablemultithreading
+        && $export_ecrf_fieldvalues_multithreading
+        && $cpucount > 1
+        && $export_ecrf_fieldvalues_numofthreads > 1
+        && (scalar @jobs) > 1);
+
+    my $results = $use_threads
+        ? _get_ecrffieldvalues_parallel(\@jobs)
+        : [ map { _fetch_ecrf_visit_fieldvalues($_); } @jobs ];
+
+    my @values;
+    $context->{ecrf_count} = 0;
+    foreach my $result (@$results) {
+        $context->{ecrf_count} += $result->{included} ? 1 : 0;
+        foreach my $log (@{$result->{logs} // []}) {
+            _info($context,$log->{text},$log->{debug},$use_threads ? $log->{tid} : undef);
+        }
+        push(@values,@{$result->{values} // []});
+    }
     return \@values;
+}
+
+sub _get_ecrffieldvalues_parallel {
+    my ($jobs) = @_;
+    my $numofthreads = $export_ecrf_fieldvalues_numofthreads;
+    $numofthreads = scalar @$jobs if $numofthreads > scalar @$jobs;
+    $numofthreads = 1 if $numofthreads < 1;
+
+    my @buckets;
+    my $i = 0;
+    foreach my $job (@$jobs) {
+        push(@{$buckets[$i % $numofthreads]},$job);
+        $i++;
+    }
+
+    my @threads;
+    foreach my $bucket (@buckets) {
+        push(@threads,threads->create(\&_get_ecrffieldvalues_worker,$bucket));
+    }
+
+    my @results;
+    my $error;
+    foreach my $thread (@threads) {
+        my $part = $thread->join();
+        if (defined $part and 'HASH' eq ref $part and $part->{error}) {
+            $error ||= $part->{error};
+            next;
+        }
+        push(@results,@{$part->{results} // []});
+    }
+    die $error if $error;
+    return \@results;
+}
+
+sub _get_ecrffieldvalues_worker {
+    my ($jobs) = @_;
+    my @out;
+    eval {
+        foreach my $job (@$jobs) {
+            push(@out,_fetch_ecrf_visit_fieldvalues($job));
+        }
+    };
+    if ($@) {
+        return { error => $@ };
+    }
+    return { results => \@out };
+}
+
+sub _fetch_ecrf_visit_fieldvalues {
+    my ($job) = @_;
+    my $listentry_id = $job->{listentry_id};
+    my $ecrfid = $job->{ecrfid};
+    my $visit_id = $job->{visit_id};
+    my $visit_label = defined $visit_id ? '@' . ($job->{visit_token} // '') : '';
+    my $alias = $job->{alias};
+    my $ecrf_name = $job->{ecrf_name};
+    my $signed = $job->{signed};
+
+    my @logs;
+    my @values;
+    my $included = 0;
+    my $tid = threadid();
+
+    my $ecrf_status = eval { CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfStatusEntry::get_item($listentry_id,$ecrfid,$visit_id) };
+    my $status_name = $ecrf_status ? $ecrf_status->{status}->{name} : '<new>';
+
+    if ($signed ? ($ecrf_status and $ecrf_status->{status}->{done})
+            : ($ecrf_data_include_undef_ecrf_status or $ecrf_status)) {
+        $included = 1;
+        push(@logs,{ text => "proband $alias: eCRF '$ecrf_name$visit_label': $status_name", debug => 0, tid => $tid });
+        my $api_values_page = [];
+        my $api_values_page_num = 0;
+        my $api_values_page_total_count;
+        while (1) {
+            if ((scalar @$api_values_page) == 0) {
+                my $p = { page_size => $ecrf_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef, total_count_expected => not defined $api_values_page_total_count };
+                my $sf = {}; #sorted by default
+
+                my $first = $api_values_page_num * $ecrf_data_api_values_page_size;
+                push(@logs,{ text => "fetch eCRF values page: " . $first . '-' . ($first + $ecrf_data_api_values_page_size) . ' of ' . (defined $api_values_page_total_count ? $api_values_page_total_count : '?'), debug => !$show_page_progress, tid => $tid });
+                eval {
+                    $api_values_page = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::EcrfFieldValues::get_ecrffieldvalues($listentry_id,$ecrfid,$visit_id,0, $timezone, $p, $sf, { _value => 1, _selectionValueMap => 1 })->{rows};
+                };
+                if ($@) {
+                    $api_values_page = [];
+                }
+                $api_values_page_total_count = $p->{total_count} if defined $p->{total_count};
+                $api_values_page_num += 1;
+            }
+            my $value = shift @$api_values_page;
+            last unless $value;
+            if (not defined $value->{index} or defined $value->{id}) {
+                push(@values,$value);
+            }
+        }
+    } else {
+        push(@logs,{ text => ($signed ? 'skipping unsigned' : 'skipping <new>') . " - proband $alias: eCRF '$ecrf_name$visit_label': $status_name", debug => 1, tid => $tid });
+    }
+    return { values => \@values, included => $included, logs => \@logs };
 }
 
 sub _run_dbtool {
@@ -1018,11 +1113,11 @@ sub _warn {
 
 sub _info {
 
-    my ($context,$message,$debug) = @_;
+    my ($context,$message,$debug,$tid) = @_;
     if ($debug) {
-        processing_debug(undef,$message,getlogger(__PACKAGE__));
+        processing_debug($tid,$message,getlogger(__PACKAGE__));
     } else {
-        processing_info(undef,$message,getlogger(__PACKAGE__));
+        processing_info($tid,$message,getlogger(__PACKAGE__));
     }
 }
 

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExport.pm
@@ -1000,7 +1000,11 @@ sub _get_ecrffieldvalues_parallel {
     my $error;
     foreach my $thread (@threads) {
         my $part = $thread->join();
-        if (defined $part and 'HASH' eq ref $part and $part->{error}) {
+        if (not defined $part) {
+            $error ||= $thread->error() || 'eCRF field-value worker returned no result';
+            next;
+        }
+        if ('HASH' eq ref $part and $part->{error}) {
             $error ||= $part->{error};
             next;
         }

--- a/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/EcrfExporter/Settings.pm
@@ -56,7 +56,10 @@ our @EXPORT_OK = qw(
 
     $proband_list_filename
     $ecrf_data_row_block
-    
+
+    $export_ecrf_fieldvalues_multithreading
+    $export_ecrf_fieldvalues_numofthreads
+
     $publish_public_file
 
 );
@@ -88,6 +91,9 @@ our $publish_public_file = 0;
 
 our $ecrf_data_row_block = 100;
 
+our $export_ecrf_fieldvalues_multithreading = $enablemultithreading;
+our $export_ecrf_fieldvalues_numofthreads = $cpucount;
+
 sub update_settings {
 
     my ($data,$configfile) = @_;
@@ -116,7 +122,11 @@ sub update_settings {
         $ecrfs_export_xls_filename = $data->{ecrfs_export_xls_filename} if exists $data->{ecrfs_export_xls_filename};
 
         $ecrf_data_row_block = $data->{ecrf_data_row_block} if exists $data->{ecrf_data_row_block};
-        
+
+        $export_ecrf_fieldvalues_multithreading = stringtobool($data->{export_ecrf_fieldvalues_multithreading}) if exists $data->{export_ecrf_fieldvalues_multithreading};
+        $export_ecrf_fieldvalues_multithreading = 0 unless $enablemultithreading;
+        $export_ecrf_fieldvalues_numofthreads = _get_numofthreads($cpucount,$data,'export_ecrf_fieldvalues_numofthreads');
+
         $publish_public_file = stringtobool($data->{publish_public_file}) if exists $data->{publish_public_file};        
 
         return $result;
@@ -124,6 +134,14 @@ sub update_settings {
     }
     return 0;
 
+}
+
+sub _get_numofthreads {
+    my ($default_value,$data,$key) = @_;
+    my $numofthreads = $default_value;
+    $numofthreads = $data->{$key} if exists $data->{$key};
+    $numofthreads = $cpucount if $numofthreads > $cpucount;
+    return $numofthreads;
 }
 
 1;

--- a/CTSMS/BulkProcessor/Projects/ETL/Inquiry.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/Inquiry.pm
@@ -119,13 +119,13 @@ sub _get_inquiries {
     my @inquiries;
     while (1) {
         if ((scalar @$api_inquiries_page) == 0) {
-            my $p = { page_size => $inquiry_data_api_inquiries_page_size , page_num => $api_inquiries_page_num + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_inquiries_page_size , page_num => $api_inquiries_page_num + 1, total_count => undef, total_count_expected => not defined $api_inquiries_page_total_count };
             my $sf = {};
 
             my $first = $api_inquiries_page_num * $inquiry_data_api_inquiries_page_size;
             _info($context,"fetch inquiries page: " . $first . '-' . ($first + $inquiry_data_api_inquiries_page_size) . ' of ' . (defined $api_inquiries_page_total_count ? $api_inquiries_page_total_count : '?'),not $show_page_progress);
             $api_inquiries_page = CTSMS::BulkProcessor::RestRequests::ctsms::trial::TrialService::Inquiry::get_trial_list($context->{inquiry_trial}->{id}, $active, $active_signup, 1, $p, $sf, { _selectionSetValueMap => 1 });
-            $api_inquiries_page_total_count = $p->{total_count};
+            $api_inquiries_page_total_count = $p->{total_count} if defined $p->{total_count};
             $api_inquiries_page_num += 1;
         }
         my $inquiry = shift @$api_inquiries_page;

--- a/CTSMS/BulkProcessor/Projects/ETL/InquiryExport.pm
+++ b/CTSMS/BulkProcessor/Projects/ETL/InquiryExport.pm
@@ -270,14 +270,14 @@ sub _init_inquiry_data_vertical_context {
 
 NEXT_PROBAND:
         if (not defined $context->{api_probands_page_total_count} or ($context->{api_probands_page_num} * $inquiry_data_api_probands_page_size < $context->{api_probands_page_total_count} and (scalar @{$context->{api_probands_page}}) == 0)) {
-            my $p = { page_size => $inquiry_data_api_probands_page_size, page_num => $context->{api_probands_page_num} + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_probands_page_size, page_num => $context->{api_probands_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_probands_page_total_count} };
             my $sf = { sort_by => 'id', sort_dir => 'asc',
                        'deferredDelete' => booltostring(0), };
 
             my $first = $context->{api_probands_page_num} * $inquiry_data_api_probands_page_size;
             _info($context,"fetch probands page: " . $first . '-' . ($first + $inquiry_data_api_probands_page_size) . ' of ' . (defined $context->{api_probands_page_total_count} ? $context->{api_probands_page_total_count} : '?'),not $show_page_progress);
             $context->{api_probands_page} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::get_inquiry_proband_list($context->{inquiry_trial}->{id}, $active, $active_signup, $p, $sf);
-            $context->{api_probands_page_total_count} = $p->{total_count};
+            $context->{api_probands_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_probands_page_num} += 1;
         }
         if (not defined $context->{proband}) {
@@ -291,7 +291,7 @@ NEXT_PROBAND:
         }
 
         if (not defined $context->{api_values_page_total_count} or ($context->{api_values_page_num} * $inquiry_data_api_values_page_size < $context->{api_values_page_total_count} and (scalar @{$context->{api_values_page}}) == 0)) {
-            my $p = { page_size => $inquiry_data_api_values_page_size , page_num => $context->{api_values_page_num} + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_values_page_size , page_num => $context->{api_values_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_values_page_total_count} };
             my $sf = {}; #sorted by default
 
             my $first = $context->{api_values_page_num} * $inquiry_data_api_values_page_size;
@@ -302,7 +302,7 @@ NEXT_PROBAND:
             if ($@) {
                 $context->{api_values_page} = [];
             }
-            $context->{api_values_page_total_count} = $p->{total_count};
+            $context->{api_values_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_values_page_num} += 1;
         }
         my $value = shift @{$context->{api_values_page}};
@@ -457,14 +457,14 @@ sub _init_inquiry_data_pdfs_context {
         my ($context) = @_;
 
         if ((scalar @{$context->{api_probands_page}}) == 0) {
-            my $p = { page_size => $inquiry_data_api_probands_page_size , page_num => $context->{api_probands_page_num} + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_probands_page_size , page_num => $context->{api_probands_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_probands_page_total_count} };
             my $sf = { sort_by => 'id', sort_dir => 'asc',
                        'deferredDelete' => booltostring(0), };
             #$sf->{fileName} = $dialysis_substitution_volume_file_pattern if defined $dialysis_substitution_volume_file_pattern;
             my $first = $context->{api_probands_page_num} * $inquiry_data_api_probands_page_size;
             _info($context,"fetch probands page: " . $first . '-' . ($first + $inquiry_data_api_probands_page_size) . ' of ' . (defined $context->{api_probands_page_total_count} ? $context->{api_probands_page_total_count} : '?'),not $show_page_progress);
             $context->{api_probands_page} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::get_inquiry_proband_list($context->{inquiry_trial}->{id}, $active, $active_signup, $p, $sf);
-            $context->{api_probands_page_total_count} = $p->{total_count};
+            $context->{api_probands_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_probands_page_num} += 1;
         }
         $context->{proband} = shift @{$context->{api_probands_page}};
@@ -508,14 +508,14 @@ sub _init_inquiry_data_horizontal_context {
         my ($context) = @_;
 
         if ((scalar @{$context->{api_probands_page}}) == 0) {
-            my $p = { page_size => $inquiry_data_api_probands_page_size , page_num => $context->{api_probands_page_num} + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_probands_page_size , page_num => $context->{api_probands_page_num} + 1, total_count => undef, total_count_expected => not defined $context->{api_probands_page_total_count} };
             my $sf = { sort_by => 'id', sort_dir => 'asc',
                        'deferredDelete' => booltostring(0), };
 
             my $first = $context->{api_probands_page_num} * $inquiry_data_api_probands_page_size;
             _info($context,"fetch probands page: " . $first . '-' . ($first + $inquiry_data_api_probands_page_size) . ' of ' . (defined $context->{api_probands_page_total_count} ? $context->{api_probands_page_total_count} : '?'),not $show_page_progress);
             $context->{api_probands_page} = CTSMS::BulkProcessor::RestRequests::ctsms::proband::ProbandService::Proband::get_inquiry_proband_list($context->{inquiry_trial}->{id}, $active, $active_signup, $p, $sf);
-            $context->{api_probands_page_total_count} = $p->{total_count};
+            $context->{api_probands_page_total_count} = $p->{total_count} if defined $p->{total_count};
             $context->{api_probands_page_num} += 1;
         }
         $context->{proband} = shift @{$context->{api_probands_page}};
@@ -607,7 +607,7 @@ sub _get_inquiryvalues {
 
     while (1) {
         if ((scalar @$api_values_page) == 0) {
-            my $p = { page_size => $inquiry_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef };
+            my $p = { page_size => $inquiry_data_api_values_page_size , page_num => $api_values_page_num + 1, total_count => undef, total_count_expected => not defined $api_values_page_total_count };
             my $sf = {}; #sorted by default
 
             my $first = $api_values_page_num * $inquiry_data_api_values_page_size;
@@ -618,7 +618,7 @@ sub _get_inquiryvalues {
             if ($@) {
                $api_values_page = [];
             }
-            $api_values_page_total_count = $p->{total_count};
+            $api_values_page_total_count = $p->{total_count} if defined $p->{total_count};
             $api_values_page_num += 1;
         }
         my $value = shift @$api_values_page;

--- a/CTSMS/BulkProcessor/RestConnector.pm
+++ b/CTSMS/BulkProcessor/RestConnector.pm
@@ -581,7 +581,7 @@ sub get_collection_page_query_uri {
         my $p = shift;
         $page_size = $p->{page_size};
         $page_num = $p->{page_num};
-        $total_count_expected = 1;
+        $total_count_expected = exists $p->{total_count_expected} ? $p->{total_count_expected} : 1;
         $sf = shift;
     } else {
         ($page_size,$page_num) = @_;

--- a/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
+++ b/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
@@ -140,9 +140,9 @@ sub _apply_jwt_claims {
     if (defined $claims->{iat}) {
         $self->{jwt_validity_secs} = int($claims->{exp}) - int($claims->{iat});
     } else {
-        # Phoenix sets exp XOR iat; remaining lifetime is still a usable duration.
-        my $remaining = int($claims->{exp}) - time();
-        $self->{jwt_validity_secs} = $remaining if $remaining > 0;
+        # Phoenix sets exp XOR iat. Remaining exp duration shrinks and can be
+        # non-positive; renewals should use the configured lifetime.
+        $self->{jwt_validity_secs} = _normalize_explicit_jwt_validity_secs();
     }
 
 }

--- a/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
+++ b/CTSMS/BulkProcessor/RestConnectors/CtsmsRestApi.pm
@@ -139,6 +139,10 @@ sub _apply_jwt_claims {
     $self->{jwt_expires} = int($claims->{exp});
     if (defined $claims->{iat}) {
         $self->{jwt_validity_secs} = int($claims->{exp}) - int($claims->{iat});
+    } else {
+        # Phoenix sets exp XOR iat; remaining lifetime is still a usable duration.
+        my $remaining = int($claims->{exp}) - time();
+        $self->{jwt_validity_secs} = $remaining if $remaining > 0;
     }
 
 }
@@ -214,7 +218,8 @@ sub extend_jwt_validity {
     unless ($renewed) {
         resterror($self, 'rest api jwt extend failed', getlogger(__PACKAGE__));
     }
-    restinfo($self, 'rest api jwt validity extended to ' . ($self->{jwt_validity_secs} // '?') . 's', getlogger(__PACKAGE__));
+    $self->{jwt_validity_secs} = $validity_secs;
+    restinfo($self, 'rest api jwt validity extended to ' . $validity_secs . 's', getlogger(__PACKAGE__));
     return 1;
 
 }
@@ -450,7 +455,9 @@ sub extract_collection_items {
 
     my $result = undef;
     if (defined $data and 'HASH' eq ref $data) {
-        if (defined $p and defined $data->{psf} and 'HASH' eq ref $data->{psf}) {
+        if (defined $p and defined $data->{psf} and 'HASH' eq ref $data->{psf}
+                and defined $data->{psf}->{totalCount}
+                and ($p->{total_count_expected} // 1)) {
             $p->{total_count} = $data->{psf}->{totalCount};
         }
         if (defined $data->{rows} and 'ARRAY' eq ref $data->{rows}) {


### PR DESCRIPTION
## Summary
- Request REST `totalCount` only on the first page of each eCRF and inquiry exporter collection (`c=false` afterwards).
- Fetch horizontal eCRF field values in parallel per eCRF×visit when global multithreading is on; stay serial otherwise. CSV column order is unchanged.
- Log JWT extend using the requested lifetime, because Phoenix tokens set `exp` or `iat`, not both.

## Test plan
- [ ] Run eCRF exporter with `enablemultithreading = 1` and confirm later pages log without recounting, workers include tid, and CSV matches a serial run.
- [ ] Run eCRF exporter with multithreading off and confirm serial fetch.
- [ ] Run inquiry exporter and confirm first-page-only `totalCount` for probands, values, and inquiry fields.
- [ ] Confirm JWT extend logs the requested seconds instead of `?s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable multithreading for horizontal eCRF field-value exports, with thread counts automatically limited to available CPU capacity.
  * Improved export progress and error reporting during parallel processing.

* **Bug Fixes**
  * Improved pagination handling across eCRF, inquiry, and proband data exports.
  * Preserved known result totals when responses omit count information, improving completeness and consistency.
  * Improved session token lifetime handling and collection metadata accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->