### PR TITLE
Stop SqlProcessor reader hang when processor threads fail during init.

### DIFF
--- a/CTSMS/BulkProcessor/SqlProcessor.pm
+++ b/CTSMS/BulkProcessor/SqlProcessor.pm
@@ -1097,6 +1097,9 @@ sub process_table {
                         delete $processors{$processor->tid()};
 
                         tablethreadingdebug('processor thread tid ' . $processor->tid() . ' joined',getlogger(__PACKAGE__));
+                    } elsif (defined $processor and not $processor->is_running()) {
+                        eval { $processor->join(); };
+                        delete $processors{$processor->tid()};
                     }
                 }
                 sleep($thread_sleep_secs);
@@ -1282,6 +1285,8 @@ sub _reader {
         $reader_db->db_get_begin($context->{selectstatement},@{$context->{values_ref}}) if $reader_db->rowblock_transactional;
         tablethreadingdebug('[' . $tid . '] reader thread waiting for consumer threads',getlogger(__PACKAGE__));
         while ((_get_other_threads_state($context->{errorstates},$tid) & $RUNNING) == 0) { #wait on cosumers to come up
+            my $other = _get_other_threads_state($context->{errorstates},$tid);
+            last if ($other & $ERROR);
             sleep($thread_sleep_secs);
         }
         my $i = 0;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processor cleanup for stopped threads that are not immediately joinable.
  * Startup now exits promptly when another processing thread reports an error, reducing unnecessary waiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->